### PR TITLE
Fix ClientConfig merging with base class

### DIFF
--- a/apiconfig/config/base.py
+++ b/apiconfig/config/base.py
@@ -194,9 +194,13 @@ class ClientConfig:
         TypeError
             If 'other' is not a ClientConfig instance.
         """
-        if not isinstance(other, self.__class__):
-            logger.warning(f"Attempted to merge ClientConfig with incompatible type: {type(other)}")
-            raise TypeError(f"Cannot merge ClientConfig with object of type {type(other)}")
+        if not isinstance(other, ClientConfig):
+            logger.warning(
+                "Attempted to merge ClientConfig with incompatible type: %s", type(other)
+            )
+            raise TypeError(
+                f"Cannot merge ClientConfig with object of type {type(other)}"
+            )
 
         # Create a deep copy of self as the base for the new instance
         new_instance = copy.deepcopy(self)

--- a/tests/unit/config/test_base.py
+++ b/tests/unit/config/test_base.py
@@ -364,3 +364,18 @@ class TestClientConfig:
 
         assert config2.hostname == "override.example.com"
         assert config2.version == "v2"  # Still from class
+
+    def test_merge_allows_base_instance(self) -> None:
+        """Merging a subclass with a base ClientConfig should succeed."""
+
+        class CustomConfig(ClientConfig):
+            pass
+
+        base_config = CustomConfig(hostname="api.example.com")
+        other_config = ClientConfig(version="v1")
+
+        merged = base_config.merge(other_config)
+
+        assert isinstance(merged, CustomConfig)
+        assert merged.hostname == "api.example.com"
+        assert merged.version == "v1"


### PR DESCRIPTION
## Summary
- allow `ClientConfig.merge` to accept base instances
- test merging subclass with base config works

## Testing
- `pytest tests/unit -q`
- `pytest -q` *(fails: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841979136dc8332b272fd24a09d05c4