### PR TITLE
Fix file_path parameter references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ config_dict = env.load()
 ```python
 from apiconfig import FileProvider, MemoryProvider
 
-file_provider = FileProvider(filepath="config.json")
+file_provider = FileProvider(file_path="config.json")
 file_config = file_provider.load()
 
 memory_provider = MemoryProvider(data={"hostname": "api.example.com"})

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -116,7 +116,7 @@ From a File
    from apiconfig import FileProvider, ClientConfig
 
    # Load from a JSON file
-   file_provider = FileProvider(filepath="config.json")
+   file_provider = FileProvider(file_path="config.json")
    config_dict = file_provider.load()
 
    # Create config from loaded values

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -65,11 +65,11 @@ Load configuration from JSON or YAML files:
    from apiconfig import FileProvider
 
    # JSON file
-   json_provider = FileProvider(filepath="config.json")
+   json_provider = FileProvider(file_path="config.json")
    json_config = json_provider.load()
 
    # YAML file
-   yaml_provider = FileProvider(filepath="config.yaml")
+   yaml_provider = FileProvider(file_path="config.yaml")
    yaml_config = yaml_provider.load()
 
 Memory Provider
@@ -217,7 +217,7 @@ Store tokens securely:
    from apiconfig.auth.token import FileTokenStorage
 
    # Store tokens in a file
-   storage = FileTokenStorage(filepath=".tokens.json")
+   storage = FileTokenStorage(file_path=".tokens.json")
 
    # Save tokens
    storage.save({


### PR DESCRIPTION
## Summary
- fix incorrect `filepath` parameter usage in README and docs

## Testing
- `pytest -q` *(fails: ProxyError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842568c0f4c833295f1a357559f1b10