### PR TITLE
Add deep copy checks to merge_configs test

### DIFF
--- a/tests/unit/config/test_base.py
+++ b/tests/unit/config/test_base.py
@@ -317,7 +317,7 @@ class TestClientConfig:
             headers={"Authorization": "Bearer token"},
             timeout=20.0,
         )
-        other_config.retries = None
+        other_config.retries = None  # type: ignore[assignment]
 
         merged = ClientConfig.merge_configs(base_config, other_config)
 

--- a/tests/unit/config/test_base.py
+++ b/tests/unit/config/test_base.py
@@ -307,13 +307,43 @@ class TestClientConfig:
 
     def test_merge_configs_static_method(self) -> None:
         """Test the merge_configs static method."""
-        base_config = ClientConfig(hostname="api.example.com")
-        other_config = ClientConfig(version="v1")
+        base_config = ClientConfig(
+            hostname="api.example.com",
+            headers={"User-Agent": "Base"},
+            retries=5,
+        )
+        other_config = ClientConfig(
+            version="v1",
+            headers={"Authorization": "Bearer token"},
+            timeout=20.0,
+        )
+        other_config.retries = None
 
         merged = ClientConfig.merge_configs(base_config, other_config)
 
+        # Base and other fields should be combined correctly
         assert merged.hostname == "api.example.com"
         assert merged.version == "v1"
+        assert merged.headers == {
+            "User-Agent": "Base",
+            "Authorization": "Bearer token",
+        }
+        assert merged.timeout == 20.0
+        assert merged.retries == 5
+
+        # Changing originals shouldn't affect merged result
+        assert base_config.headers is not None
+        base_config.headers["User-Agent"] = "Modified"
+        base_config.timeout = 30.0
+        assert other_config.headers is not None
+        other_config.headers["Authorization"] = "Modified"
+        other_config.timeout = 5.0
+
+        assert merged.headers == {
+            "User-Agent": "Base",
+            "Authorization": "Bearer token",
+        }
+        assert merged.timeout == 20.0
 
     def test_merge_configs_with_incompatible_types(self) -> None:
         """Test that merge_configs raises TypeError with incompatible types."""


### PR DESCRIPTION
## Summary
- improve `test_merge_configs_static_method`
- check header merging and ensure returned config is independent

## Testing
- `pytest -q tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_684256d0b284833280c317f9820acbff