### PR TITLE
Fix version retrieval

### DIFF
--- a/apiconfig/__init__.py
+++ b/apiconfig/__init__.py
@@ -8,6 +8,7 @@ strategies (Basic, Bearer, API Key, etc.).
 """
 
 import logging
+from importlib.metadata import version
 
 # Core components re-exported for easier access
 from .auth.base import AuthStrategy
@@ -42,7 +43,7 @@ from .types import (
     TokenStorageStrategy,
 )
 
-__version__: str = "0.3.0"
+__version__: str = version("apiconfig")
 
 # Define public API
 __all__: list[str] = [


### PR DESCRIPTION
## Summary
- remove unnecessary try/except around `__version__`
- rely solely on package metadata for version

## Testing
- `pytest tests/integration/test_apiconfig_jsonplaceholder.py::test_jsonplaceholder_get_post_1 -q` *(fails: ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_684256bd8f708332b3e07091362c8826