### PR TITLE
Fix comment wording in redaction tests

### DIFF
--- a/tests/unit/utils/redaction/test_body.py
+++ b/tests/unit/utils/redaction/test_body.py
@@ -189,14 +189,14 @@ SENSITIVE_VALUE_PATTERN_UUID = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-
             SENSITIVE_KEY_PATTERN,
             None,
             "not json",
-        ),  # Unparseable JSON
+        ),  # Unparsable JSON
         (
             "a=b=c",
             "application/x-www-form-urlencoded",
             SENSITIVE_KEY_PATTERN,
             None,
             "a=b%3Dc",
-        ),  # Unparseable form (sort of)
+        ),  # Unparsable form (sort of)
         (
             {"password": "secret", "user": "test"},
             None,


### PR DESCRIPTION
## Summary
- fix spelling in `test_body.py` comments

## Testing
- `pytest tests/unit/utils/redaction/test_body.py::test_redact_body -q`

------
https://chatgpt.com/codex/tasks/task_e_6842783f39788332914d145d676a3c62