### PR TITLE
Fix HTTP verb case in docs

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -120,7 +120,7 @@ Tripletex API (API Key + Token)
            "expirationDate": "2025-04-23",  # Tomorrow
        }
 
-       response = httpx.PUT(url, params=params)
+       response = httpx.put(url, params=params)
        if response.status_code == 200:
            data = response.json()
            return data["value"]["token"]


### PR DESCRIPTION
## Summary
- correct the Tripletex example to call `httpx.put` instead of the invalid `httpx.PUT`

## Testing
- `pytest -q` *(fails: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68427e94966483329886d3b3ced3f894