### PR TITLE
Add fallback version handling test

### DIFF
--- a/apiconfig/__init__.py
+++ b/apiconfig/__init__.py
@@ -8,7 +8,7 @@ strategies (Basic, Bearer, API Key, etc.).
 """
 
 import logging
-from importlib.metadata import version
+import importlib.metadata
 
 # Core components re-exported for easier access
 from .auth.base import AuthStrategy
@@ -43,7 +43,10 @@ from .types import (
     TokenStorageStrategy,
 )
 
-__version__: str = version("apiconfig")
+try:
+    __version__: str = importlib.metadata.version("apiconfig")
+except importlib.metadata.PackageNotFoundError:  # pragma: no cover - fallback for local use
+    __version__ = "0.0.0"
 
 # Define public API
 __all__: list[str] = [

--- a/apiconfig/__init__.py
+++ b/apiconfig/__init__.py
@@ -7,8 +7,8 @@ This library provides components for managing API client configurations
 strategies (Basic, Bearer, API Key, etc.).
 """
 
-import logging
 import importlib.metadata
+import logging
 
 # Core components re-exported for easier access
 from .auth.base import AuthStrategy

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,17 @@
+import importlib
+import importlib.metadata
+
+
+class TestVersion:
+    """Tests for package version handling."""
+
+    def test_version_defaults_to_zero_when_package_missing(self, monkeypatch) -> None:
+        """__version__ should fallback to '0.0.0' when package metadata is missing."""
+
+        def raise_package_not_found(_name: str) -> str:
+            raise importlib.metadata.PackageNotFoundError
+
+        monkeypatch.setattr(importlib.metadata, "version", raise_package_not_found)
+
+        module = importlib.reload(importlib.import_module("apiconfig"))
+        assert module.__version__ == "0.0.0"

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,11 +1,13 @@
 import importlib
 import importlib.metadata
 
+import pytest
+
 
 class TestVersion:
     """Tests for package version handling."""
 
-    def test_version_defaults_to_zero_when_package_missing(self, monkeypatch) -> None:
+    def test_version_defaults_to_zero_when_package_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """__version__ should fallback to '0.0.0' when package metadata is missing."""
 
         def raise_package_not_found(_name: str) -> str:


### PR DESCRIPTION
## Summary
- handle missing version metadata by defaulting to `0.0.0`
- test that `__version__` falls back when metadata is absent

## Testing
- `pytest tests/unit/test_version.py -q`
- `pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_68427feddf9c8332af4a8fe3261db4e7