### PR TITLE
Improve url utility test coverage

### DIFF
--- a/tests/unit/utils/url/test_parsing.py
+++ b/tests/unit/utils/url/test_parsing.py
@@ -94,6 +94,18 @@ def test_parse_url_edge_cases() -> None:
     assert result.fragment == "frag"
 
 
+def test_parse_url_custom_default_scheme() -> None:
+    """Ensure parse_url uses the provided default scheme when missing."""
+    # When the URL lacks a scheme, the provided default should be applied
+    result = parse_url("example.org/api", default_scheme="http")
+    assert result.scheme == "http"
+    assert result.netloc == "example.org"
+
+    # Existing schemes should be preserved regardless of default
+    result = parse_url("https://example.org/api", default_scheme="http")
+    assert result.scheme == "https"
+
+
 # --- Tests for get_query_params ---
 @pytest.mark.parametrize(
     "url_in, expected_params",
@@ -310,3 +322,14 @@ def test_add_query_params_edge_cases() -> None:
     long_value = "x" * 1000  # 1000 character string
     result = add_query_params("https://example.com", {"long": long_value})
     assert get_query_params(result)["long"] == long_value
+
+
+def test_add_query_params_replace() -> None:
+    """Test add_query_params with replace=True overwrites existing params."""
+    url = "https://example.com/path?a=1&b=2"
+    result = add_query_params(url, {"b": None, "c": "3"}, replace=True)
+    assert result == "https://example.com/path?c=3"
+
+    url2 = "https://example.com/path?a=1"
+    result2 = add_query_params(url2, {"b": "2"}, replace=True)
+    assert result2 == "https://example.com/path?b=2"


### PR DESCRIPTION
## Summary
- extend `parse_url` tests for custom default scheme handling
- add test cases for `add_query_params` with `replace=True`

## Testing
- `env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY pytest -q -k "not integration" -o addopts=""`

------
https://chatgpt.com/codex/tasks/task_e_68428f9f9b4c8332b92b2c0988344c29