### PR TITLE
Add module documentation

### DIFF
--- a/apiconfig/README.md
+++ b/apiconfig/README.md
@@ -1,0 +1,54 @@
+# apiconfig
+
+Python library for building API clients with flexible configuration and pluggable
+authentication. This package exposes the public API used by applications while
+internal subpackages provide the implementation details.
+
+## Contents
+- `auth/` – authentication framework and built‑in strategies.
+- `config/` – `ClientConfig` class and configuration providers.
+- `exceptions/` – structured error hierarchy for configuration and HTTP issues.
+- `testing/` – helpers and fixtures for unit and integration tests.
+- `utils/` – assorted utilities such as logging setup and URL helpers.
+- `__init__.py` – re‑exports common classes and determines the package version.
+
+## Quick example
+```python
+from apiconfig import ClientConfig, ApiKeyAuth
+
+config = ClientConfig(hostname="api.example.com", auth_strategy=ApiKeyAuth("key"))
+print(config.base_url)
+```
+
+## Key components
+| Component | Description |
+| --------- | ----------- |
+| `ClientConfig` | Holds API connection settings like base URL, timeouts and authentication. |
+| `AuthStrategy` and friends | Base class and built‑in strategies for headers or token handling. |
+| `ConfigManager` | Loads and merges configuration from providers. |
+| `EnvProvider` / `FileProvider` / `MemoryProvider` | Sources for configuration data. |
+| `APIConfigError` and subclasses | Domain specific exceptions for reporting failures. |
+
+### Design
+`apiconfig` is organised into small focused modules. Authentication strategies
+implement the **Strategy** pattern while configuration providers can be combined
+in any order via `ConfigManager`.
+
+```mermaid
+flowchart TD
+    Provider1 --> Manager
+    Provider2 --> Manager
+    Manager --> ClientConfig
+    ClientConfig --> AuthStrategy
+```
+
+## Testing
+Install dependencies and run the full test suite:
+```bash
+python -m pip install -e .
+python -m pip install pytest pytest-httpserver pytest-xdist
+pytest -q
+```
+
+## Status
+Stable – actively maintained with high test coverage.

--- a/apiconfig/config/README.md
+++ b/apiconfig/config/README.md
@@ -1,0 +1,59 @@
+# apiconfig.config
+
+Core configuration system for **apiconfig**.  This module exposes the `ClientConfig`
+class used by API clients and the `ConfigManager` which coordinates loading of
+configuration values from one or more providers.
+
+## Contents
+- `base.py` – `ClientConfig` with helpers for merging settings and constructing `base_url`.
+- `manager.py` – `ConfigManager` that merges dictionaries from multiple providers.
+- `providers/` – built‑in configuration providers such as `EnvProvider` and `FileProvider`.
+- `__init__.py` – re‑exports the main classes for convenience.
+
+## Example usage
+```python
+from apiconfig.config import ClientConfig, ConfigManager
+from apiconfig.config.providers import EnvProvider, FileProvider
+
+providers = [EnvProvider(prefix="MYAPP_"), FileProvider("config.json")]
+manager = ConfigManager(providers)
+config_data = manager.load_config()
+
+config = ClientConfig(**config_data)
+print(config.base_url)
+```
+
+## Key classes
+| Class | Description |
+| ----- | ----------- |
+| `ClientConfig` | Stores hostname, API version, headers, timeouts and authentication strategy. |
+| `ConfigManager` | Loads configuration from providers and merges them in order. |
+| `EnvProvider` / `FileProvider` / `MemoryProvider` | Return configuration dictionaries from environment, JSON files or in‑memory data. |
+
+### Design
+The manager and providers follow a simple **Strategy** style. Each provider
+defines a `load()` (or `get_config()`) method returning a dictionary. The
+`ConfigManager` merges these dictionaries in sequence so later providers override
+previous ones.
+
+```mermaid
+flowchart TB
+    subgraph Providers
+        A[EnvProvider] --> M
+        B[FileProvider] --> M
+        C[MemoryProvider] --> M
+    end
+    M[ConfigManager] --> D[dict]
+    D -->|\*args| ClientConfig
+```
+
+## Tests
+Install dependencies and run the unit tests for the configuration package:
+```bash
+python -m pip install -e .
+python -m pip install pytest
+pytest tests/unit/config -q
+```
+
+## Status
+Stable – used by API clients and covered by unit tests.

--- a/apiconfig/testing/README.md
+++ b/apiconfig/testing/README.md
@@ -1,0 +1,47 @@
+# apiconfig.testing
+
+Testing utilities bundled with **apiconfig**. This package organises helpers for
+both unit and integration tests so developers can verify clients without writing
+boilerplate code.
+
+## Contents
+- `unit/` – assertions, factories and mocks for isolated unit tests.
+- `integration/` – fixtures and HTTP server helpers for end‑to‑end scenarios.
+- `auth_verification.py` – common checks for authentication headers during tests.
+- `__init__.py` – exposes the most useful helpers across subpackages.
+
+## Example
+```python
+from apiconfig.testing.integration import configure_mock_response
+from apiconfig.testing.unit import create_valid_client_config
+
+config = create_valid_client_config(hostname="api.test")
+configure_mock_response(httpserver, path="/ping", response_data={"ok": True})
+```
+
+## Key modules
+| Module | Purpose |
+| ------ | ------- |
+| `unit` | Mocks and assertions for fast unit tests. |
+| `integration` | Spin up mock HTTP servers and provide fixtures for real‑world flows. |
+| `auth_verification` | Advanced helpers for verifying auth behaviour in tests. |
+
+### Diagram
+```mermaid
+flowchart TD
+    subgraph Testing
+        U[unit] -- mocks --> T[tests]
+        I[integration] -- fixtures --> T
+    end
+```
+
+## Running tests
+Install dependencies and run all project tests:
+```bash
+python -m pip install -e .
+python -m pip install pytest pytest-httpserver pytest-xdist
+pytest -q
+```
+
+## Status
+Internal – APIs may evolve alongside the test suite.

--- a/apiconfig/testing/unit/README.md
+++ b/apiconfig/testing/unit/README.md
@@ -1,0 +1,55 @@
+# apiconfig.testing.unit
+
+Helpers for writing unit tests against **apiconfig**. The package provides
+assertions, factory functions and mock objects so tests remain concise and free
+of external dependencies.
+
+## Contents
+- `assertions.py` – convenience assertions such as `assert_client_config_valid`.
+- `factories.py` – factory helpers for creating valid or invalid `ClientConfig` instances.
+- `helpers.py` – misc utilities including context managers for temp files and env vars.
+- `mocks/` – lightweight mock implementations of auth strategies and config providers.
+- `__init__.py` – re-exports the most common helpers.
+
+## Example
+```python
+from apiconfig.testing.unit import (
+    create_valid_client_config,
+    MockConfigProvider,
+    MockConfigManager,
+)
+
+provider = MockConfigProvider({"hostname": "api.test"})
+manager = MockConfigManager([provider])
+config = manager.load_config()
+assert config.hostname == "api.test"
+```
+
+## Key helpers
+| Helper | Description |
+| ------ | ----------- |
+| `create_valid_client_config` | Returns a ready-to-use `ClientConfig` for tests. |
+| `MockConfigProvider` / `MockConfigManager` | Duck-typed providers and manager with `MagicMock` behaviour. |
+| `assert_client_config_valid` | Asserts that a config object has sensible values. |
+
+### Design
+Mocks and helpers follow minimal design to keep test code straightforward. They
+mirror the real classes closely so they can be swapped in without altering
+production code.
+
+```mermaid
+flowchart TD
+    MockConfigProvider --> MockConfigManager --> ClientConfig
+    MockConfigManager -->|load_config| dict
+```
+
+## Running tests
+Install dependencies and execute the unit tests for this package:
+```bash
+python -m pip install -e .
+python -m pip install pytest pytest-xdist
+pytest tests/unit/testing/unit -q
+```
+
+## Status
+Internal – provided for the project's own unit tests.

--- a/apiconfig/utils/README.md
+++ b/apiconfig/utils/README.md
@@ -1,0 +1,50 @@
+# apiconfig.utils
+
+Miscellaneous utilities shipped with **apiconfig**. They cover HTTP helpers,
+URL construction, redaction of sensitive data and logging setup. Each subpackage
+can be used independently by API clients.
+
+## Contents
+- `http.py` – simple helpers for working with HTTP status codes and JSON payloads.
+- `url.py` – safe wrappers around `urllib.parse` for building URLs.
+- `redaction/` – functions for scrubbing secrets from bodies and headers.
+- `logging/` – custom formatters and setup helpers for the library's logging.
+- `__init__.py` – exposes the modules above for convenience.
+
+## Example
+```python
+from apiconfig.utils import http, url
+
+if http.is_success(200):
+    full_url = url.build_url("https://api.example.com", "/ping")
+    print(full_url)
+```
+
+## Key modules
+| Module | Purpose |
+| ------ | ------- |
+| `http` | HTTP status helpers and safe JSON encode/decode with custom exceptions. |
+| `url` | Build URLs and normalise query parameters with type safety. |
+| `redaction` | Remove sensitive data before logging or output. |
+| `logging` | Formatters, handlers and setup utilities for clean log output. |
+
+### Design
+Utility modules are kept lightweight and independent. Logging utilities compose
+the redaction helpers to avoid code duplication.
+
+```mermaid
+flowchart TD
+    Redaction --> Logging
+    URL --> HTTP
+```
+
+## Tests
+Run the unit tests for utility modules:
+```bash
+python -m pip install -e .
+python -m pip install pytest pytest-xdist
+pytest tests/unit/utils -q
+```
+
+## Status
+Stable – used throughout the project.

--- a/apiconfig/utils/logging/README.md
+++ b/apiconfig/utils/logging/README.md
@@ -1,0 +1,54 @@
+# apiconfig.utils.logging
+
+Logging helpers used across **apiconfig**. This package bundles custom
+formatters, context filters and convenience functions for setting up redacted
+logging output.
+
+## Contents
+- `filters.py` – thread-local `ContextFilter` and helper functions for log context.
+- `handlers.py` – `ConsoleHandler` and `RedactingStreamHandler` wrappers around `logging.StreamHandler`.
+- `formatters/` – specialised formatters like `DetailedFormatter` and `RedactingFormatter`.
+- `setup.py` – `setup_logging` function to configure the library's logger.
+- `__init__.py` – exports the common classes and helpers.
+
+## Example
+```python
+import logging
+from apiconfig.utils.logging import setup_logging
+
+setup_logging(level="INFO")
+logger = logging.getLogger("apiconfig")
+logger.info("configured")
+```
+
+## Key classes and functions
+| Name | Description |
+| ---- | ----------- |
+| `ContextFilter` | Injects request or user context into log records via thread-local storage. |
+| `DetailedFormatter` | Formats log messages with extra location information. |
+| `RedactingFormatter` | Strips sensitive data using the redaction utilities. |
+| `setup_logging` | Convenience function to configure handlers and formatters. |
+
+### Design
+The components follow a compositional approach: formatters delegate redaction to
+`apiconfig.utils.redaction` and `setup_logging` wires up handlers with chosen
+formatters. Context injection is optional via the filter.
+
+```mermaid
+flowchart TD
+    Logger -- filter --> ContextFilter
+    Logger --> Handler
+    Handler --> Formatter
+    Formatter -->|redact| Redaction
+```
+
+## Tests
+Run the logging-related unit tests:
+```bash
+python -m pip install -e .
+python -m pip install pytest pytest-xdist
+pytest tests/unit/utils/logging -q
+```
+
+## Status
+Stable – provides common logging setup for the library.


### PR DESCRIPTION
## Summary
- document the root `apiconfig` package
- document configuration package and providers
- add READMEs for testing utilities
- document logging utilities and general utils

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_6842a19bb3bc833282b4916acbdd7e15