### PR TITLE
Improve version test

### DIFF
--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -17,3 +17,11 @@ class TestVersion:
 
         module = importlib.reload(importlib.import_module("apiconfig"))
         assert module.__version__ == "0.0.0"
+
+    def test_version_uses_metadata_when_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """__version__ should use the value from package metadata when available."""
+
+        monkeypatch.setattr(importlib.metadata, "version", lambda _name: "1.2.3")
+
+        module = importlib.reload(importlib.import_module("apiconfig"))
+        assert module.__version__ == "1.2.3"


### PR DESCRIPTION
## Summary
- add regression test for retrieving version info from package metadata

## Testing
- `poetry run pre-commit run --files tests/unit/test_version.py` *(fails: httpx.ProxyError during integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_6842a2b28408833290e842acc7a83d71