### PR TITLE
Fix docs to reference EnvProvider

### DIFF
--- a/docs/source/crudclient_integration.rst
+++ b/docs/source/crudclient_integration.rst
@@ -43,12 +43,12 @@ Advanced Integration with Custom Configuration
 .. code-block:: python
 
     from apiconfig.config import ConfigManager
-    from apiconfig.config.providers import EnvConfigProvider
+    from apiconfig.config.providers import EnvProvider
     from apiconfig.auth.strategies import BearerAuth
 
     # Load configuration
     config_manager = ConfigManager()
-    config_manager.add_provider(EnvConfigProvider())
+    config_manager.add_provider(EnvProvider())
     config = config_manager.get_config()
 
     # Set up auth with configuration

--- a/project_plans/finished/crudclient_integration_implementation/tasks/phase3_task5_documentation_examples.md
+++ b/project_plans/finished/crudclient_integration_implementation/tasks/phase3_task5_documentation_examples.md
@@ -239,12 +239,12 @@ Advanced Integration with Custom Configuration
 .. code-block:: python
 
     from apiconfig.config import ConfigManager
-    from apiconfig.config.providers import EnvConfigProvider
+    from apiconfig.config.providers import EnvProvider
     from apiconfig.auth.strategies import BearerAuth
 
     # Load configuration
     config_manager = ConfigManager()
-    config_manager.add_provider(EnvConfigProvider())
+    config_manager.add_provider(EnvProvider())
     config = config_manager.get_config()
 
     # Set up auth with configuration


### PR DESCRIPTION
## Summary
- replace EnvConfigProvider with EnvProvider in docs

## Testing
- `poetry run pre-commit run --files docs/source/crudclient_integration.rst project_plans/finished/crudclient_integration_implementation/tasks/phase3_task5_documentation_examples.md`

------
https://chatgpt.com/codex/tasks/task_e_6842a8b3a5bc8332ac1f26f3ffe4f7ce