### PR TITLE
Skip live integration tests

### DIFF
--- a/tests/integration/test_apiconfig_fiken.py
+++ b/tests/integration/test_apiconfig_fiken.py
@@ -2,6 +2,12 @@ import os
 
 import pytest
 
+if os.getenv("PYTEST_SKIP_INTEGRATION", "false").lower() == "true":
+    pytest.skip(
+        "Integration tests disabled (PYTEST_SKIP_INTEGRATION=true)",
+        allow_module_level=True,
+    )
+
 from apiconfig.auth.strategies.bearer import BearerAuth
 from apiconfig.config.base import ClientConfig
 from apiconfig.config.manager import ConfigManager

--- a/tests/integration/test_apiconfig_jsonplaceholder.py
+++ b/tests/integration/test_apiconfig_jsonplaceholder.py
@@ -1,10 +1,18 @@
 import os
 from typing import Any, Dict
 
+import pytest
+
 import httpx
 
 from apiconfig.config.base import ClientConfig
 from apiconfig.config.providers.env import EnvProvider
+
+if os.getenv("PYTEST_SKIP_INTEGRATION", "false").lower() == "true":
+    pytest.skip(
+        "Integration tests disabled (PYTEST_SKIP_INTEGRATION=true)",
+        allow_module_level=True,
+    )
 
 
 def test_jsonplaceholder_get_post_1() -> None:

--- a/tests/integration/test_apiconfig_jsonplaceholder.py
+++ b/tests/integration/test_apiconfig_jsonplaceholder.py
@@ -1,9 +1,8 @@
 import os
 from typing import Any, Dict
 
-import pytest
-
 import httpx
+import pytest
 
 from apiconfig.config.base import ClientConfig
 from apiconfig.config.providers.env import EnvProvider

--- a/tests/integration/test_apiconfig_oneflow.py
+++ b/tests/integration/test_apiconfig_oneflow.py
@@ -12,6 +12,12 @@ import os
 
 import pytest
 
+if os.getenv("PYTEST_SKIP_INTEGRATION", "false").lower() == "true":
+    pytest.skip(
+        "Integration tests disabled (PYTEST_SKIP_INTEGRATION=true)",
+        allow_module_level=True,
+    )
+
 from apiconfig.auth.strategies.api_key import ApiKeyAuth
 from apiconfig.config.base import ClientConfig
 from apiconfig.config.manager import ConfigManager

--- a/tests/integration/test_apiconfig_tripletex.py
+++ b/tests/integration/test_apiconfig_tripletex.py
@@ -8,7 +8,14 @@ This test demonstrates comprehensive usage of apiconfig patterns:
 - Modern HTTP client integration with proper error handling
 """
 
+import os
 import pytest
+
+if os.getenv("PYTEST_SKIP_INTEGRATION", "false").lower() == "true":
+    pytest.skip(
+        "Integration tests disabled (PYTEST_SKIP_INTEGRATION=true)",
+        allow_module_level=True,
+    )
 
 from apiconfig.config.base import ClientConfig
 from apiconfig.config.manager import ConfigManager

--- a/tests/integration/test_apiconfig_tripletex.py
+++ b/tests/integration/test_apiconfig_tripletex.py
@@ -9,6 +9,7 @@ This test demonstrates comprehensive usage of apiconfig patterns:
 """
 
 import os
+
 import pytest
 
 if os.getenv("PYTEST_SKIP_INTEGRATION", "false").lower() == "true":

--- a/tests/integration/test_tripletex_auth_refresh.py
+++ b/tests/integration/test_tripletex_auth_refresh.py
@@ -6,11 +6,18 @@ successful API calls.
 """
 
 import logging
+import os
 import threading
 from datetime import datetime, timedelta, timezone
 
 import pytest
 from pytest import LogCaptureFixture
+
+if os.getenv("PYTEST_SKIP_INTEGRATION", "false").lower() == "true":
+    pytest.skip(
+        "Integration tests disabled (PYTEST_SKIP_INTEGRATION=true)",
+        allow_module_level=True,
+    )
 
 from apiconfig.exceptions.auth import TokenRefreshError
 from helpers_for_tests.tripletex.tripletex_auth import TripletexSessionAuth


### PR DESCRIPTION
## Summary
- ensure integration tests that hit live APIs are skipped when `PYTEST_SKIP_INTEGRATION=true`
- remove duplicate skip checks in Fiken, OneFlow and Tripletex tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a868d9708332856aa682a94629de