### PR TITLE
Fix unauthorized spelling

### DIFF
--- a/apiconfig/utils/logging/formatters/README.md
+++ b/apiconfig/utils/logging/formatters/README.md
@@ -28,7 +28,7 @@ logger.info("Configuration loaded")
 secure_handler = logging.StreamHandler()
 secure_handler.setFormatter(RedactingFormatter())
 logger.addHandler(secure_handler)
-logger.warning({"token": "secret", "msg": "unauthorised"})
+logger.warning({"token": "secret", "msg": "unauthorized"})
 ```
 
 ## Key classes


### PR DESCRIPTION
## Summary
- update logging formatter README to use American spelling

## Testing
- `pytest --cov=apiconfig --cov-report=html` *(fails: No module named 'httpx', 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6842b075a708833298b0dde50db1971b