### PR TITLE
Fix EnvProvider prefix in integration fixtures

### DIFF
--- a/apiconfig/testing/integration/fixtures.py
+++ b/apiconfig/testing/integration/fixtures.py
@@ -63,7 +63,7 @@ def env_provider(monkeypatch: pytest.MonkeyPatch) -> EnvProvider:  # Corrected t
     monkeypatch.setenv("APICONFIG_API_HOSTNAME", "env.example.com")  # Hostname usually overridden by mock_api_url in tests
     monkeypatch.setenv("APICONFIG_AUTH_TYPE", "env_bearer")
     monkeypatch.setenv("APICONFIG_AUTH_TOKEN", "env_token_123")
-    return EnvProvider(prefix="APICONFIG")  # Corrected class instantiation
+    return EnvProvider(prefix="APICONFIG_")  # Corrected prefix with underscore
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/testing/integration/test_fixtures.py
+++ b/tests/unit/testing/integration/test_fixtures.py
@@ -116,7 +116,7 @@ class TestEnvProvider:
         monkeypatch.setenv("APICONFIG_AUTH_TOKEN", "env_token_123")
 
         # Create an EnvProvider directly
-        provider = EnvProvider(prefix="APICONFIG")
+        provider = EnvProvider(prefix="APICONFIG_")
 
         # Check that the provider is an EnvProvider
         assert isinstance(provider, EnvProvider)
@@ -129,6 +129,7 @@ class TestEnvProvider:
         # Check that the provider has the correct prefix
         # Check that the provider has the expected prefix
         assert hasattr(provider, "_prefix")
+        assert provider._prefix == "APICONFIG_"
 
 
 class TestConfigManager:


### PR DESCRIPTION
## Summary
- correct EnvProvider prefix to `APICONFIG_`
- update integration test fixture expectations

## Testing
- `pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b07c552c8332b21b2952261f3b83