### PR TITLE
Fix outdated comments in fixtures

### DIFF
--- a/apiconfig/testing/integration/fixtures.py
+++ b/apiconfig/testing/integration/fixtures.py
@@ -58,16 +58,16 @@ def file_provider(temp_config_file: Path) -> FileProvider:
 
 
 @pytest.fixture(scope="function")
-def env_provider(monkeypatch: pytest.MonkeyPatch) -> EnvProvider:  # Corrected type hint
-    """Provide an EnvProvider with predefined env vars."""
+def env_provider(monkeypatch: pytest.MonkeyPatch) -> EnvProvider:
+    """Provide an EnvProvider with predefined environment variables."""
     monkeypatch.setenv("APICONFIG_API_HOSTNAME", "env.example.com")  # Hostname usually overridden by mock_api_url in tests
     monkeypatch.setenv("APICONFIG_AUTH_TYPE", "env_bearer")
     monkeypatch.setenv("APICONFIG_AUTH_TOKEN", "env_token_123")
-    return EnvProvider(prefix="APICONFIG")  # Corrected class instantiation
+    return EnvProvider(prefix="APICONFIG")
 
 
 @pytest.fixture(scope="function")
-def config_manager(file_provider: FileProvider, env_provider: EnvProvider) -> ConfigManager:  # Corrected type hint
+def config_manager(file_provider: FileProvider, env_provider: EnvProvider) -> ConfigManager:
     """Provide a ConfigManager instance with file and env providers."""
     # Order matters: env overrides file by default
     return ConfigManager(providers=[file_provider, env_provider])


### PR DESCRIPTION
## Summary
- refresh comments in `fixtures.py` for clarity

## Testing
- `pre-commit run --files apiconfig/testing/integration/fixtures.py` *(fails: ProxyError)*
- `pytest tests/integration/test_apiconfig_jsonplaceholder.py::test_jsonplaceholder_get_post_1 -vv` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_6842b08950e88332bf13f3fd61098c8a