### PR TITLE
Add array case to safe_json_decode failure tests

### DIFF
--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -154,6 +154,12 @@ def test_safe_json_decode_success(content: str | bytes, encoding: str | None, ex
             JSONDecodeError,
             "Failed to decode response body",
         ),  # Invalid UTF-8 start byte
+        (
+            "[]",
+            None,
+            JSONDecodeError,
+            "Decoded JSON is not an object",
+        ),  # JSON array instead of object
         # Removed problematic test case: (b'{"key": "value"}', "ascii", JSONDecodeError, "Failed to decode response body"),
         (
             123,


### PR DESCRIPTION
## Summary
- improve `test_safe_json_decode_failure` by verifying list input raises `JSONDecodeError`
- run style checks with **isort**, **black** and **flake8**
- run targeted unit test

## Testing
- `isort tests/unit/utils/test_http.py`
- `black tests/unit/utils/test_http.py`
- `flake8`
- `pytest tests/unit/utils/test_http.py::test_safe_json_decode_failure -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c2830e088332ac50ce5b3b0ec3f0