### PR TITLE
Improve parse_url tests

### DIFF
--- a/tests/unit/utils/url/test_parsing.py
+++ b/tests/unit/utils/url/test_parsing.py
@@ -40,6 +40,14 @@ from apiconfig.utils.url import add_query_params, get_query_params, parse_url
             "/api",
         ),  # IP address with port
         ("https://[2001:db8::1]/path", "https", "[2001:db8::1]", "/path"),  # IPv6
+        (
+            "[2001:db8::1]:8080/path",
+            "https",
+            "[2001:db8::1]:8080",
+            "/path",
+        ),  # IPv6 with port
+        ("localhost", "", "", "localhost"),  # No scheme for bare hostname
+        ("relative/path", "", "", "relative/path"),  # Relative path without leading slash
     ],
 )
 def test_parse_url(url_in: str, expected_scheme: str, expected_netloc: str, expected_path: str) -> None:


### PR DESCRIPTION
## Summary
- extend parse_url unit test with IPv6 and localhost cases
- ensure relative-path handling is covered

## Testing
- `pytest -c /dev/null tests/unit/utils/url/test_parsing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6842c27f148c833287b76ab509a9c23b