### PR TITLE
Improve BaseClient handle_response test coverage

### DIFF
--- a/tests/unit/helpers/common/test_base_client.py
+++ b/tests/unit/helpers/common/test_base_client.py
@@ -46,3 +46,12 @@ def test_handle_response_invalid_json() -> None:
     response = httpx.Response(status_code=200, text="{invalid json")
     with pytest.raises(JSONDecodeError):
         client._handle_response(response, HttpMethod.GET, "https://example.com/test")
+
+
+@pytest.mark.parametrize("body", ["", "null", "123", '"text"'])
+def test_handle_response_empty_or_non_object_returns_empty_dict(body: str) -> None:
+    """Non-object JSON bodies should result in an empty dict."""
+    client = _make_client()
+    response = httpx.Response(status_code=200, text=body)
+    result = client._handle_response(response, HttpMethod.GET, "https://example.com/test")
+    assert result == {}


### PR DESCRIPTION
## Summary
- add parametrized test for `_handle_response` handling of empty and non-object JSON bodies

## Testing
- `isort tests/unit/helpers/common/test_base_client.py`
- `black tests/unit/helpers/common/test_base_client.py`
- `flake8 tests/unit/helpers/common/test_base_client.py`
- `pytest -q tests/unit/helpers/common/test_base_client.py`
- `pytest -q tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_6842c27928908332ac06ac60c1679080