### PR TITLE
Fix typo in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,7 +6,7 @@ of the License, or (at your option) any later version.
 apiconfig is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesset General Public License for more details.
+GNU Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public License
-along with apiconfig.  If not, see <http://www.gnu.org/licenses/>.
+along with apiconfig.  If not, see <http://www.gnu.org/licenses/>


### PR DESCRIPTION
## Summary
- fix spelling of "GNU Lesser" in license file

## Testing
- `pytest -q` *(fails: unrecognized arguments)*
- `pytest -q` after installing pytest-xdist *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842c7545e8483329e9629f892c82625