### PR TITLE
Fix BearerAuth docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ auth = ApiKeyAuth(api_key="my-secret-key", param_name="api_key")
 from apiconfig import BasicAuth, BearerAuth
 
 basic = BasicAuth(username="user", password="pass")
-bearer = BearerAuth(token="my-jwt-token")
+bearer = BearerAuth(access_token="my-jwt-token")
 ```
 
 #### Custom Authentication

--- a/docs/source/api/auth.rst
+++ b/docs/source/api/auth.rst
@@ -24,7 +24,10 @@ The refresh callback interface is designed for integration with HTTP client retr
 .. code-block:: python
 
     # Get refresh callback for integration with retry logic
-    auth_strategy = BearerAuth(token="your_token", refresh_token="refresh_token")
+    auth_strategy = BearerAuth(
+        access_token="your_token",
+        http_request_callable=http_request_func,
+    )  # BearerAuth.refresh() requires custom implementation
     refresh_callback = auth_strategy.get_refresh_callback()
 
     if refresh_callback:

--- a/docs/source/auth_refresh_guide.rst
+++ b/docs/source/auth_refresh_guide.rst
@@ -28,18 +28,19 @@ Basic Refresh Pattern
         return requests.request(method, url, headers=headers, data=data)
 
     auth_strategy = BearerAuth(
-        token="current_access_token",
-        refresh_token="current_refresh_token",
-        token_url="https://api.example.com/oauth/token",
-        http_request_callable=http_request_func
+        access_token="current_access_token",
+        http_request_callable=http_request_func,
     )
+
+    # BearerAuth.refresh() must be implemented by a subclass
+    # or by providing custom logic using the HTTP callback.
 
     # Check if refresh is supported
     if auth_strategy.can_refresh():
         print("Auth strategy supports refresh")
 
-    # Manually refresh if needed
-    if auth_strategy.is_expired():
+    # Manually refresh if your subclass implements it
+    if auth_strategy.can_refresh() and auth_strategy.is_expired():
         result = auth_strategy.refresh()
         if result and result.get("token_data"):
             # Save new tokens

--- a/docs/source/crudclient_integration.rst
+++ b/docs/source/crudclient_integration.rst
@@ -18,10 +18,8 @@ Basic Integration
         return requests.request(method, url, headers=headers, json=data)
 
     auth_strategy = BearerAuth(
-        token="your_access_token",
-        refresh_token="your_refresh_token",
-        token_url="https://api.example.com/oauth/token",
-        http_request_callable=make_http_request
+        access_token="your_access_token",
+        http_request_callable=make_http_request,
     )
 
     # Create crudclient with auth refresh integration
@@ -53,10 +51,8 @@ Advanced Integration with Custom Configuration
 
     # Set up auth with configuration
     auth_strategy = BearerAuth(
-        token=config["access_token"],
-        refresh_token=config["refresh_token"],
-        token_url=config["token_url"],
-        http_request_callable=make_http_request
+        access_token=config["access_token"],
+        http_request_callable=make_http_request,
     )
 
     # Use with crudclient

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -68,7 +68,7 @@ Bearer Token Authentication
 
    from apiconfig import ClientConfig, BearerAuth
 
-   auth = BearerAuth(token="my-jwt-token")
+   auth = BearerAuth(access_token="my-jwt-token")
    config = ClientConfig(
        hostname="api.example.com",
        version="v1",
@@ -133,7 +133,7 @@ Using with HTTP Clients
    from apiconfig import ClientConfig, BearerAuth
 
    # Set up configuration
-   auth = BearerAuth(token="my-jwt-token")
+   auth = BearerAuth(access_token="my-jwt-token")
    config = ClientConfig(
        hostname="api.example.com",
        version="v1",

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -146,7 +146,7 @@ JWT or OAuth token authentication:
 
    from apiconfig import BearerAuth
 
-   auth = BearerAuth(token="my-jwt-token")
+   auth = BearerAuth(access_token="my-jwt-token")
 
    # Get headers for a request
    headers = auth.prepare_request_headers()
@@ -311,7 +311,7 @@ Best Practices
           env = EnvProvider(prefix="MYAPI_")
           config_dict = env.load()
 
-          auth = BearerAuth(token=config_dict.get("TOKEN"))
+        auth = BearerAuth(access_token=config_dict.get("TOKEN"))
           return ClientConfig(
               hostname=config_dict.get("HOSTNAME", "api.default.com"),
               version=config_dict.get("VERSION", "v1"),


### PR DESCRIPTION
## Summary
- correct BearerAuth usage examples
- clarify auth refresh guide and crudclient integration docs

## Testing
- `pytest -q` *(fails: Unknown config option and missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6842c75345f88332aec435cd958ae2f5