### PR TITLE
Fix ApiKeyAuth docs

### DIFF
--- a/apiconfig/README.md
+++ b/apiconfig/README.md
@@ -16,7 +16,10 @@ internal subpackages provide the implementation details.
 ```python
 from apiconfig import ClientConfig, ApiKeyAuth
 
-config = ClientConfig(hostname="api.example.com", auth_strategy=ApiKeyAuth("key"))
+config = ClientConfig(
+    hostname="api.example.com",
+    auth_strategy=ApiKeyAuth(api_key="key", header_name="X-API-Key"),
+)
 print(config.base_url)
 ```
 

--- a/project_plans/finished/crudclient_integration_implementation/tasks/phase3_final_validation.md
+++ b/project_plans/finished/crudclient_integration_implementation/tasks/phase3_final_validation.md
@@ -185,7 +185,7 @@ def test_existing_functionality():
     headers = bearer_auth.prepare_request_headers()
     assert headers["Authorization"] == "Bearer token"
 
-    api_key_auth = ApiKeyAuth("key")
+    api_key_auth = ApiKeyAuth(api_key="key", header_name="X-API-Key")
     headers = api_key_auth.prepare_request_headers()
     assert headers["X-API-Key"] == "key"
 


### PR DESCRIPTION
## Summary
- correct ApiKeyAuth example in project plan docs

## Testing
- `pytest -q` *(fails: ImportError for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_6842c75241948332910f2bda6b348c7a