### PR TITLE
Fix ConfigManager example in docs

### DIFF
--- a/docs/source/crudclient_integration.rst
+++ b/docs/source/crudclient_integration.rst
@@ -45,9 +45,10 @@ Advanced Integration with Custom Configuration
     from apiconfig.auth.strategies import BearerAuth
 
     # Load configuration
-    config_manager = ConfigManager()
-    config_manager.add_provider(EnvProvider())
-    config = config_manager.get_config()
+    # ConfigManager accepts the providers in its constructor and
+    # ``load_config`` returns the merged dictionary.
+    config_manager = ConfigManager([EnvProvider()])
+    config = config_manager.load_config()
 
     # Set up auth with configuration
     auth_strategy = BearerAuth(


### PR DESCRIPTION
## Summary
- fix instructions in `crudclient_integration.rst` to match the actual `ConfigManager` API

## Testing
- `pytest tests/unit/config/test_manager.py::TestConfigManager::test_init -q`

------
https://chatgpt.com/codex/tasks/task_e_6843623187d08332a252045c59eb86fd