### PR TITLE
Fix flake8 reference in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ All contributions and interactions must align with the project's [Code of Conduc
 
 - **Black:** Code formatting
 - **isort:** Import sorting
-- **Flake8:** Linting (configured in `setup.cfg` or `pyproject.toml`)
+ - **Flake8:** Linting (configured in `.flake8`)
 - **autoflake:** Removes unused imports/variables
 - **Mypy:** Static type checking (configured in `mypy.ini` or `pyproject.toml`)
 


### PR DESCRIPTION
## Summary
- correct flake8 configuration path in CONTRIBUTING

## Testing
- `poetry run pre-commit run --files CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_6843cc937ee083328a182938b30962b2