### PR TITLE
Fix docs for FileProvider YAML support

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -58,7 +58,7 @@ Load configuration from environment variables:
 File Provider
 ^^^^^^^^^^^
 
-Load configuration from JSON or YAML files:
+Load configuration from JSON files:
 
 .. code-block:: python
 
@@ -68,9 +68,6 @@ Load configuration from JSON or YAML files:
    json_provider = FileProvider(file_path="config.json")
    json_config = json_provider.load()
 
-   # YAML file
-   yaml_provider = FileProvider(file_path="config.yaml")
-   yaml_config = yaml_provider.load()
 
 Memory Provider
 ^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- correct the FileProvider docs in user_guide

## Testing
- `poetry run pre-commit run --files docs/source/user_guide.rst`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843cc9289908332be9df22628ded565