### PR TITLE
Fix MemoryProvider docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,10 @@ from apiconfig import FileProvider, MemoryProvider
 file_provider = FileProvider(file_path="config.json")
 file_config = file_provider.load()
 
-memory_provider = MemoryProvider(data={"hostname": "api.example.com"})
-memory_config = memory_provider.load()
+# MemoryProvider accepts configuration via the ``config_data`` parameter and
+# exposes ``get_config`` instead of ``load``
+memory_provider = MemoryProvider(config_data={"hostname": "api.example.com"})
+memory_config = memory_provider.get_config()
 ```
 
 ### Merging Configurations

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -84,8 +84,10 @@ Use in-memory configuration:
        "version": "v2",
        "timeout": 15.0,
    }
-   memory_provider = MemoryProvider(data=data)
-   config_dict = memory_provider.load()
+   # ``MemoryProvider`` stores data passed via ``config_data`` and returns it via
+   # ``get_config``
+   memory_provider = MemoryProvider(config_data=data)
+   config_dict = memory_provider.get_config()
 
 Authentication Strategies
 -----------------------


### PR DESCRIPTION
## Summary
- fix `MemoryProvider` usage in README
- clarify `MemoryProvider` example in user guide

## Testing
- `pre-commit run --files README.md docs/source/user_guide.rst`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d5932628833292e5687162a63717