### PR TITLE
Implement ConfigProvider protocol

### DIFF
--- a/apiconfig/config/manager.py
+++ b/apiconfig/config/manager.py
@@ -1,12 +1,24 @@
 """Manages loading configuration from multiple providers."""
 
 import logging
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Protocol, Sequence
 
 from apiconfig.exceptions.config import ConfigLoadError
 
-# Placeholder for a potential future ConfigProvider protocol or base class
-ConfigProvider = Any
+
+class _SupportsLoad(Protocol):
+    """Protocol for providers implementing ``load``."""
+
+    def load(self) -> Dict[str, Any]: ...
+
+
+class _SupportsGetConfig(Protocol):
+    """Protocol for providers implementing ``get_config``."""
+
+    def get_config(self) -> Dict[str, Any]: ...
+
+
+ConfigProvider = _SupportsLoad | _SupportsGetConfig
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/apiconfig/testing/integration/helpers.py
+++ b/apiconfig/testing/integration/helpers.py
@@ -10,7 +10,7 @@ from pytest_httpserver import HTTPServer
 
 from apiconfig.auth.base import AuthStrategy
 from apiconfig.config.base import ClientConfig
-from apiconfig.config.manager import ConfigManager
+from apiconfig.config.manager import ConfigManager, ConfigProvider
 from apiconfig.config.providers.memory import MemoryProvider
 from apiconfig.testing.integration.servers import configure_mock_response
 
@@ -107,11 +107,11 @@ def setup_multi_provider_manager(
     ConfigManager
         A configured ConfigManager instance.
     """
-    providers = []
+    providers: list[ConfigProvider] = []
     for name, data in config_sources:
         providers.append(MemoryProvider(config_data=data))
         # Store name as an attribute for testing
-        providers[-1].name = name  # type: ignore[attr-defined]
+        providers[-1].name = name  # type: ignore[union-attr]
     return ConfigManager(providers=providers)
 
 

--- a/helpers_for_tests/fiken/fiken_config.py
+++ b/helpers_for_tests/fiken/fiken_config.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 
 from apiconfig.auth.strategies.bearer import BearerAuth
 from apiconfig.config.base import ClientConfig
-from apiconfig.config.manager import ConfigManager
+from apiconfig.config.manager import ConfigManager, ConfigProvider
 from apiconfig.config.providers.env import EnvProvider
 from apiconfig.config.providers.memory import MemoryProvider
 from apiconfig.exceptions.auth import MissingCredentialsError
@@ -31,7 +31,7 @@ def create_fiken_config_manager() -> ConfigManager:
         "timeout": "10.0",
     }
 
-    providers = [
+    providers: list[ConfigProvider] = [
         EnvProvider(prefix="FIKEN_"),
         MemoryProvider(config_data=defaults),
     ]

--- a/helpers_for_tests/oneflow/oneflow_config.py
+++ b/helpers_for_tests/oneflow/oneflow_config.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 
 from apiconfig.auth.strategies.api_key import ApiKeyAuth
 from apiconfig.config.base import ClientConfig
-from apiconfig.config.manager import ConfigManager
+from apiconfig.config.manager import ConfigManager, ConfigProvider
 from apiconfig.config.providers.env import EnvProvider
 from apiconfig.config.providers.memory import MemoryProvider
 from apiconfig.exceptions.auth import MissingCredentialsError
@@ -31,7 +31,7 @@ def create_oneflow_config_manager() -> ConfigManager:
         "timeout": "10.0",
     }
 
-    providers = [
+    providers: list[ConfigProvider] = [
         EnvProvider(prefix="ONEFLOW_"),
         MemoryProvider(config_data=defaults),
     ]

--- a/helpers_for_tests/tripletex/tripletex_config.py
+++ b/helpers_for_tests/tripletex/tripletex_config.py
@@ -7,7 +7,7 @@ import pytest
 from dotenv import load_dotenv
 
 from apiconfig.config.base import ClientConfig
-from apiconfig.config.manager import ConfigManager
+from apiconfig.config.manager import ConfigManager, ConfigProvider
 from apiconfig.config.providers.env import EnvProvider
 from apiconfig.config.providers.memory import MemoryProvider
 from helpers_for_tests.tripletex.tripletex_auth import TripletexSessionAuth
@@ -34,7 +34,7 @@ def create_tripletex_config_manager() -> ConfigManager:
     }
 
     # Create providers - environment variables first, then defaults
-    providers = [
+    providers: list[ConfigProvider] = [
         EnvProvider(prefix="TRIPLETEX_TEST_"),
         MemoryProvider(config_data=defaults),
     ]

--- a/tests/unit/config/test_manager.py
+++ b/tests/unit/config/test_manager.py
@@ -1,11 +1,11 @@
 """Tests for the ConfigManager class."""
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import pytest
 
-from apiconfig.config.manager import ConfigManager
+from apiconfig.config.manager import ConfigManager, ConfigProvider
 from apiconfig.exceptions.config import ConfigLoadError
 
 
@@ -120,7 +120,7 @@ class TestConfigManager:
     def test_load_config_provider_with_no_method(self) -> None:
         """Test loading config from a provider with neither load nor get_config."""
         provider = MockProviderWithNoMethod()
-        manager = ConfigManager(providers=[provider])
+        manager = ConfigManager(providers=[cast(ConfigProvider, provider)])
 
         with pytest.raises(ConfigLoadError, match="lacks a 'load' or 'get_config' method"):
             manager.load_config()
@@ -197,7 +197,7 @@ class TestConfigManager:
                 return "BadProvider"
 
         provider = BadProvider()
-        manager = ConfigManager(providers=[provider])
+        manager = ConfigManager(providers=[cast(ConfigProvider, provider)])
 
         # This should not raise an error, but should log a warning
         config = manager.load_config()


### PR DESCRIPTION
## Summary
- define `ConfigProvider` protocol with `load()` and `get_config()`
- annotate `ConfigManager` with this protocol

## Testing
- `pre-commit run --files apiconfig/config/manager.py`

------
https://chatgpt.com/codex/tasks/task_e_684566d1baf48332bd8b04f81e6fbb96