### PR TITLE
Expose UrlencodeParamsType

### DIFF
--- a/apiconfig/types.py
+++ b/apiconfig/types.py
@@ -55,7 +55,7 @@ QueryParamType: TypeAlias = Mapping[str, QueryParamValueType]
 """Type alias for URL query parameters."""
 
 # Internal type for urllib.parse.urlencode
-_UrlencodeParamsType: TypeAlias = Dict[str, Union[str, List[str]]]
+UrlencodeParamsType: TypeAlias = Dict[str, Union[str, List[str]]]
 """Internal type for urllib.parse.urlencode compatibility."""
 
 DataType: TypeAlias = Union[str, bytes, JsonObject, Mapping[str, Any]]
@@ -238,7 +238,7 @@ __all__ = [
     "HeadersType",
     "QueryParamType",
     "QueryParamValueType",
-    "_UrlencodeParamsType",
+    "UrlencodeParamsType",
     "DataType",
     "ResponseBodyType",
     "HttpRequestProtocol",

--- a/apiconfig/utils/url.py
+++ b/apiconfig/utils/url.py
@@ -7,10 +7,10 @@ adding only type safety and parameter normalization.
 import urllib.parse
 from typing import Any, Dict, List, Optional, Union, cast
 
-from apiconfig.types import QueryParamType, _UrlencodeParamsType
+from apiconfig.types import QueryParamType, UrlencodeParamsType
 
 
-def normalize_query_params(params: Optional[QueryParamType]) -> _UrlencodeParamsType:
+def normalize_query_params(params: Optional[QueryParamType]) -> UrlencodeParamsType:
     """
     Convert QueryParamType to format expected by urllib.parse.urlencode.
 
@@ -19,7 +19,7 @@ def normalize_query_params(params: Optional[QueryParamType]) -> _UrlencodeParams
     if not params:
         return {}
 
-    result: _UrlencodeParamsType = {}
+    result: UrlencodeParamsType = {}
     for key, value in params.items():
         if value is None:
             continue  # Skip None values
@@ -124,14 +124,14 @@ def add_query_params(url: str, params: QueryParamType, replace: bool = False) ->
     # Add new parameters
     normalized_new_params = normalize_query_params(params_to_add)
 
-    final_params: _UrlencodeParamsType
+    final_params: UrlencodeParamsType
     if replace:
         final_params = normalized_new_params
     else:
         # Start with existing params, then update with new ones
         # Cast to the correct type since existing_params is Dict[str, List[str]]
         # but final_params needs to be Dict[str, Union[str, List[str]]]
-        final_params = cast(_UrlencodeParamsType, dict(existing_params))
+        final_params = cast(UrlencodeParamsType, dict(existing_params))
         final_params.update(normalized_new_params)
 
         # Remove parameters that were set to None


### PR DESCRIPTION
## Summary
- rename `_UrlencodeParamsType` to `UrlencodeParamsType`
- export `UrlencodeParamsType` in `__all__`
- update URL utilities to use the new public type

## Testing
- `pre-commit run --files apiconfig/types.py apiconfig/utils/url.py`
- `poetry run pyright apiconfig/utils/url.py apiconfig/types.py`
- `poetry run mypy apiconfig/utils/url.py apiconfig/types.py`
- `poetry run flake8 apiconfig/utils/url.py apiconfig/types.py`
- `poetry run isort --check apiconfig/utils/url.py apiconfig/types.py`
- `poetry run black --check apiconfig/utils/url.py apiconfig/types.py`
- `poetry run pytest tests/unit/ -v -q`


------
https://chatgpt.com/codex/tasks/task_e_68456d724d4c83329dcd3887f1753c2b