### PR TITLE
Update redaction types

### DIFF
--- a/apiconfig/utils/redaction/body.py
+++ b/apiconfig/utils/redaction/body.py
@@ -29,7 +29,7 @@ def _redact_recursive(
                 redacted_dict[key] = _redact_recursive(value, key_pattern, value_pattern)
         return redacted_dict
     elif isinstance(data, list):
-        typed_list: List[Any] = cast(List[Any], data)
+        typed_list: List[Any] = data
         return [_redact_recursive(item, key_pattern, value_pattern) for item in typed_list]
     elif isinstance(data, str) and value_pattern and value_pattern.search(data):
         return REDACTED_VALUE
@@ -130,18 +130,12 @@ def redact_body(
 
     except (json.JSONDecodeError, TypeError, ValueError):
         # If parsing fails, return original string/bytes or placeholder
-        result: Union[str, bytes, Any] = cast(
-            Union[str, bytes, Any],
-            body_str if body_str is not None else body,
-        )
+        result: Union[str, bytes, Any] = body_str if body_str is not None else body
         return result
 
     # 4. If not JSON or form, or if parsing failed, return original/placeholder
     # If it was originally bytes but couldn't be decoded, placeholder was returned earlier.
     # If it was originally a string/bytes but not JSON/Form, return original.
     # If it was already parsed but not dict/list, return original.
-    result_final: Union[str, bytes, Any] = cast(
-        Union[str, bytes, Any],
-        body_str if body_str is not None else body,
-    )
+    result_final: Union[str, bytes, Any] = body_str if body_str is not None else body
     return result_final

--- a/apiconfig/utils/redaction/body.py
+++ b/apiconfig/utils/redaction/body.py
@@ -3,7 +3,7 @@
 
 import json
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union, cast
 from urllib.parse import parse_qs, urlencode
 
 from .headers import REDACTED_VALUE
@@ -21,15 +21,17 @@ def _redact_recursive(
 ) -> Any:
     """Recursively redact sensitive data in dictionaries and lists."""
     if isinstance(data, dict):
-        redacted_dict = {}
-        for key, value in data.items():
+        typed_dict: Dict[str, Any] = cast(Dict[str, Any], data)
+        redacted_dict: Dict[str, Any] = {}
+        for key, value in typed_dict.items():
             if key_pattern.search(key):
                 redacted_dict[key] = REDACTED_VALUE
             else:
                 redacted_dict[key] = _redact_recursive(value, key_pattern, value_pattern)
         return redacted_dict
     elif isinstance(data, list):
-        return [_redact_recursive(item, key_pattern, value_pattern) for item in data]
+        typed_list: List[Any] = list(cast(Sequence[Any], data))
+        return [_redact_recursive(item, key_pattern, value_pattern) for item in typed_list]
     elif isinstance(data, str) and value_pattern and value_pattern.search(data):
         return REDACTED_VALUE
     else:
@@ -38,11 +40,11 @@ def _redact_recursive(
 
 
 def redact_body(
-    body: Union[str, bytes, Any],
+    body: Union[str, bytes, Dict[str, Any], List[Any], Any],
     content_type: Optional[str] = None,
     sensitive_keys_pattern: re.Pattern[str] = DEFAULT_SENSITIVE_KEYS_PATTERN,
     sensitive_value_pattern: Optional[re.Pattern[str]] = None,
-) -> Union[str, bytes, Any]:
+) -> Union[str, bytes, Dict[str, Any], List[Any], Any]:
     """Redact sensitive information from request or response bodies.
 
     Attempts to parse JSON or form-urlencoded bodies and recursively redacts
@@ -112,7 +114,7 @@ def redact_body(
             # Return in original format (parsed dict/list or JSON string)
             return json.dumps(redacted_data) if body_str is not None else redacted_data
         elif is_form and body_str is not None:
-            parsed_form = parse_qs(body_str, keep_blank_values=True)
+            parsed_form: Dict[str, List[str]] = parse_qs(body_str, keep_blank_values=True)
             redacted_form: Dict[str, List[str]] = {}
             for key, values in parsed_form.items():
                 if sensitive_keys_pattern.search(key):
@@ -120,7 +122,7 @@ def redact_body(
                 else:
                     # Check individual values if a value pattern is provided
                     if sensitive_value_pattern:
-                        redacted_values = [REDACTED_VALUE if sensitive_value_pattern.search(v) else v for v in values]
+                        redacted_values: List[str] = [REDACTED_VALUE if sensitive_value_pattern.search(v) else v for v in values]
                         redacted_form[key] = redacted_values
                     else:
                         redacted_form[key] = values
@@ -129,10 +131,18 @@ def redact_body(
 
     except (json.JSONDecodeError, TypeError, ValueError):
         # If parsing fails, return original string/bytes or placeholder
-        return body_str if body_str is not None else body  # Or consider REDACTED_BODY_PLACEHOLDER
+        result: Union[str, bytes, Dict[str, Any], List[Any]] = cast(
+            Union[str, bytes, Dict[str, Any], List[Any]],
+            body_str if body_str is not None else body,
+        )
+        return result
 
     # 4. If not JSON or form, or if parsing failed, return original/placeholder
     # If it was originally bytes but couldn't be decoded, placeholder was returned earlier.
     # If it was originally a string/bytes but not JSON/Form, return original.
     # If it was already parsed but not dict/list, return original.
-    return body_str if body_str is not None else body
+    result_final: Union[str, bytes, Dict[str, Any], List[Any]] = cast(
+        Union[str, bytes, Dict[str, Any], List[Any]],
+        body_str if body_str is not None else body,
+    )
+    return result_final


### PR DESCRIPTION
## Summary
- improve typing for `_redact_recursive`
- use typed parsed and redacted forms in `redact_body`
- clarify result typing to satisfy pyright

## Testing
- `pre-commit run --files apiconfig/utils/redaction/body.py`


------
https://chatgpt.com/codex/tasks/task_e_68456fbcbd7c8332be9c9151b5c315e0