### PR TITLE
Fix pyright error in ApiClientError

### DIFF
--- a/apiconfig/exceptions/http.py
+++ b/apiconfig/exceptions/http.py
@@ -6,7 +6,7 @@ exceptions where applicable.
 """
 
 import json
-from typing import Dict, Optional, Type, final
+from typing import Dict, List, Optional, Type, final
 
 from apiconfig.types import HttpRequestProtocol, HttpResponseProtocol
 
@@ -129,7 +129,7 @@ class ApiClientError(APIConfigError, HttpContextMixin):
         # Get the base message directly from Exception to avoid multiple inheritance issues
         base_message = Exception.__str__(self)
 
-        context_parts = []
+        context_parts: List[str] = []
         if self.status_code:
             context_parts.append(f"HTTP {self.status_code}")
 


### PR DESCRIPTION
## Summary
- fix typing in `ApiClientError.__str__`

## Testing
- `poetry run pytest tests/unit/exceptions/test_http_exceptions.py::TestApiClientError::test_initialization_with_full_context -q`
- `poetry run pyright apiconfig/exceptions/http.py -p pyrightconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68456fb8058c8332b24a940be28e0ffe