### PR TITLE
Allow numeric strings for config values

### DIFF
--- a/apiconfig/config/base.py
+++ b/apiconfig/config/base.py
@@ -120,8 +120,7 @@ class ClientConfig:
         timeout_value = timeout if timeout is not None else self.__class__.timeout
         # Validate timeout (must be non-negative number)
         if timeout_value is not None:
-            if not isinstance(timeout_value, (int, float)):
-                raise InvalidConfigError("Timeout must be a number (int or float).")
+            timeout_value = float(timeout_value)
             if timeout_value < 0:
                 raise InvalidConfigError("Timeout must be non-negative.")
         self.timeout = timeout_value
@@ -130,8 +129,7 @@ class ClientConfig:
         retries_value = retries if retries is not None else self.__class__.retries
         # Validate retries (must be non-negative number)
         if retries_value is not None:
-            if not isinstance(retries_value, (int, float)):
-                raise InvalidConfigError("Retries must be a number (int or float).")
+            retries_value = int(retries_value)
             if retries_value < 0:
                 raise InvalidConfigError("Retries must be non-negative.")
         self.retries = retries_value
@@ -224,15 +222,13 @@ class ClientConfig:
 
         # Validate timeout (must be non-negative number)
         if new_instance.timeout is not None:
-            if not isinstance(new_instance.timeout, (int, float)):
-                raise InvalidConfigError("Merged timeout must be a number (int or float).")
+            new_instance.timeout = float(new_instance.timeout)
             if new_instance.timeout < 0:
                 raise InvalidConfigError("Merged timeout must be non-negative.")
 
         # Validate retries (must be non-negative number)
         if new_instance.retries is not None:
-            if not isinstance(new_instance.retries, (int, float)):
-                raise InvalidConfigError("Merged retries must be a number (int or float).")
+            new_instance.retries = int(new_instance.retries)
             if new_instance.retries < 0:
                 raise InvalidConfigError("Merged retries must be non-negative.")
 

--- a/tests/unit/config/test_base.py
+++ b/tests/unit/config/test_base.py
@@ -90,15 +90,15 @@ class TestClientConfig:
         with pytest.raises(InvalidConfigError, match="Retries must be non-negative"):
             ClientConfig(retries=-1)
 
-    def test_init_validation_non_numeric_timeout(self) -> None:
-        """Test that ClientConfig raises InvalidConfigError for non-numeric timeout."""
-        with pytest.raises(InvalidConfigError, match="Timeout must be a number"):
-            ClientConfig(timeout="10")  # type: ignore[arg-type]
+    def test_init_accepts_string_timeout(self) -> None:
+        """Timeout provided as a string should be accepted and cast to float."""
+        config = ClientConfig(timeout="10")  # type: ignore[arg-type]
+        assert config.timeout == 10.0
 
-    def test_init_validation_non_numeric_retries(self) -> None:
-        """Test that ClientConfig raises InvalidConfigError for non-numeric retries."""
-        with pytest.raises(InvalidConfigError, match="Retries must be a number"):
-            ClientConfig(retries="3")  # type: ignore[arg-type]
+    def test_init_accepts_string_retries(self) -> None:
+        """Retries provided as a string should be accepted and cast to int."""
+        config = ClientConfig(retries="3")  # type: ignore[arg-type]
+        assert config.retries == 3
 
     def test_init_validation_version_leading_slash(self) -> None:
         """Test that ClientConfig raises InvalidConfigError for version with leading slash."""
@@ -242,27 +242,27 @@ class TestClientConfig:
         with pytest.raises(InvalidConfigError, match="Merged timeout must be non-negative"):
             base_config.merge(other_config)
 
-    def test_merge_validation_non_numeric_timeout(self) -> None:
-        """Test that merged config validates timeout is numeric."""
+    def test_merge_accepts_string_timeout(self) -> None:
+        """Merging with timeout as string should cast to float."""
         base_config = ClientConfig()
         other_config = ClientConfig()
 
-        # Set non-numeric timeout
+        # Set timeout as string
         other_config.timeout = "20.0"  # type: ignore[assignment]
 
-        with pytest.raises(InvalidConfigError, match="Merged timeout must be a number"):
-            base_config.merge(other_config)
+        merged = base_config.merge(other_config)
+        assert merged.timeout == 20.0
 
-    def test_merge_validation_non_numeric_retries(self) -> None:
-        """Test that merged config validates retries is numeric."""
+    def test_merge_accepts_string_retries(self) -> None:
+        """Merging with retries as string should cast to int."""
         base_config = ClientConfig()
         other_config = ClientConfig()
 
-        # Set non-numeric retries
+        # Set retries as string
         other_config.retries = "5"  # type: ignore[assignment]
 
-        with pytest.raises(InvalidConfigError, match="Merged retries must be a number"):
-            base_config.merge(other_config)
+        merged = base_config.merge(other_config)
+        assert merged.retries == 5
 
     def test_merge_validation_version_with_slashes(self) -> None:
         """Test that merged config validates version has no leading/trailing slashes."""


### PR DESCRIPTION
## Summary
- relax timeout and retries validation
- accept numeric strings for timeout and retries in tests

## Testing
- `poetry run pre-commit run --files apiconfig/config/base.py tests/unit/config/test_base.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684583726be08332a2ed31a5be58b0b6