### PR TITLE
Fix urllib error imports

### DIFF
--- a/helpers_for_tests/tripletex/tripletex_auth.py
+++ b/helpers_for_tests/tripletex/tripletex_auth.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import logging
+import urllib.error
 import urllib.parse
 import urllib.request
 from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
## Summary
- import urllib.error in Tripletex helpers
- ensure error handlers use urllib.error

## Testing
- `pre-commit run --files helpers_for_tests/tripletex/tripletex_auth.py`
- `pytest tests/integration/test_tripletex_auth_refresh.py::TestTripletexAuthRefresh::test_refresh -q`

------
https://chatgpt.com/codex/tasks/task_e_68458375a8f48332ab6279c8a11c679c