### PR TITLE
Fix pyright lambda warning in tests

### DIFF
--- a/tests/unit/utils/logging/formatters/test_redacting.py
+++ b/tests/unit/utils/logging/formatters/test_redacting.py
@@ -531,11 +531,11 @@ def test_redacting_formatter_line_224_direct(monkeypatch: pytest.MonkeyPatch) ->
     custom_output = CustomOutput()
 
     # Override redact_body to return our custom output using monkeypatch
-    monkeypatch.setattr(
-        fmt,
-        "_redact_body",
-        lambda msg, **kwargs: custom_output if msg == custom_input else msg,
-    )
+
+    def _fake_redact_body(msg: Any, **kwargs: Any) -> Any:
+        return custom_output if msg == custom_input else msg
+
+    monkeypatch.setattr(fmt, "_redact_body", _fake_redact_body)
 
     try:
         # Call _redact_structured with our custom input


### PR DESCRIPTION
## Summary
- replace lambda with helper `_fake_redact_body` in `test_redacting_formatter_line_224_direct`

## Testing
- `poetry run pre-commit run --files tests/unit/utils/logging/formatters/test_redacting.py`

------
https://chatgpt.com/codex/tasks/task_e_684583760e2c833287dde0b6b41659cc