### PR TITLE
Remove merge_configs type checking

### DIFF
--- a/apiconfig/config/base.py
+++ b/apiconfig/config/base.py
@@ -272,8 +272,6 @@ class ClientConfig:
         """Merge two ClientConfig instances.
 
         Static method wrapper around the instance merge() method.
-        This is a convenience method that validates both arguments are
-        ClientConfig instances before calling merge().
 
         Args
         ----
@@ -287,12 +285,5 @@ class ClientConfig:
         _TClientConfig
             A new ClientConfig instance representing the merged configuration.
 
-        Raises
-        ------
-        TypeError
-            If either argument is not an instance of ClientConfig.
         """
-        if not isinstance(base_config, ClientConfig) or not isinstance(other_config, ClientConfig):
-            raise TypeError("Both arguments must be instances of ClientConfig")
-
         return base_config.merge(other_config)

--- a/tests/unit/config/test_base.py
+++ b/tests/unit/config/test_base.py
@@ -346,14 +346,14 @@ class TestClientConfig:
         assert merged.timeout == 20.0
 
     def test_merge_configs_with_incompatible_types(self) -> None:
-        """Test that merge_configs raises TypeError with incompatible types."""
+        """Test error handling when merge_configs receives invalid types."""
         config = ClientConfig()
 
-        with pytest.raises(TypeError, match="Both arguments must be instances of ClientConfig"):
+        with pytest.raises(TypeError, match="Cannot merge ClientConfig with object of type"):
             ClientConfig.merge_configs(config, "not a ClientConfig")  # type: ignore[type-var]
 
-        with pytest.raises(TypeError, match="Both arguments must be instances of ClientConfig"):
-            ClientConfig.merge_configs("not a ClientConfig", config)  # type: ignore[type-var]
+        with pytest.raises(AttributeError):
+            ClientConfig.merge_configs("not a ClientConfig", config)  # type: ignore[arg-type]
 
     def test_deep_copy_on_merge(self) -> None:
         """Test that merge creates deep copies of mutable attributes."""


### PR DESCRIPTION
## Summary
- simplify ClientConfig.merge_configs
- update tests for new behavior

## Testing
- `pre-commit run --all-files`
- `poetry run pytest tests/unit -v --maxfail=1 -n auto`

------
https://chatgpt.com/codex/tasks/task_e_684588a04e3c83329a74db2eba0af641