### PR TITLE
Modify test_http identity helper

### DIFF
--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -263,12 +263,17 @@ def test_safe_json_encode_exceeds_size_limit() -> None:
         safe_json_encode(large_data, max_size_bytes=50)
 
 
+def identity(x: Any) -> Any:
+    """Return ``x`` unchanged."""
+    return x
+
+
 @pytest.mark.parametrize(
     "data, expected_exception, match",
     [
         (object(), JSONEncodeError, "Failed to encode data as JSON"),
         (set([1, 2, 3]), JSONEncodeError, "Failed to encode data as JSON"),
-        (lambda x: x, JSONEncodeError, "Failed to encode data as JSON"),
+        (identity, JSONEncodeError, "Failed to encode data as JSON"),
     ],
 )
 def test_safe_json_encode_non_serializable(data: Any, expected_exception: type[APIConfigError], match: str) -> None:


### PR DESCRIPTION
## Summary
- replace anonymous lambda with `identity` helper in http tests
- document import of `Any`

## Testing
- `poetry run pre-commit run --files tests/unit/utils/test_http.py`
- `poetry run pyright`
- `poetry run pytest tests/unit/utils/test_http.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684588a41cec833280073bcd8d6142b1