### PR TITLE
Update httpx imports for integration helpers

### DIFF
--- a/apiconfig/testing/integration/helpers.py
+++ b/apiconfig/testing/integration/helpers.py
@@ -5,7 +5,7 @@
 import typing
 import uuid
 
-import httpx
+from httpx import Client, Response
 from pytest_httpserver import HTTPServer
 
 from apiconfig.auth.base import AuthStrategy
@@ -24,7 +24,7 @@ def make_request_with_config(
     path: str,
     method: str = "GET",
     **kwargs: typing.Any,
-) -> httpx.Response:
+) -> Response:
     """Make an HTTP request using the provided config and auth strategy to a mock server.
 
     Handles applying authentication via the strategy's `prepare_request` method.
@@ -42,12 +42,12 @@ def make_request_with_config(
     method : str, optional
         The HTTP method.
     **kwargs : Any
-        Additional arguments passed to `httpx.Client.request`.
+        Additional arguments passed to `Client.request`.
 
     Returns
     -------
-    httpx.Response
-        The httpx.Response object.
+    Response
+        The httpx Response object.
     """
     base_url = mock_server_url.rstrip("/")
     url = f"{base_url}/{path.lstrip('/')}"
@@ -71,9 +71,9 @@ def make_request_with_config(
     # Ensure headers are always dicts (not mocks)
     safe_headers = dict(prepared_headers)
 
-    # Use httpx for the actual request
+    # Use httpx's Client for the actual request
     # Use verify=False for self-signed certs often used by pytest-httpserver
-    with httpx.Client(
+    with Client(
         base_url=base_url,
         timeout=config.timeout,
         follow_redirects=True,  # Typically desired in tests

--- a/tests/unit/testing/integration/test_helpers.py
+++ b/tests/unit/testing/integration/test_helpers.py
@@ -35,7 +35,7 @@ class TestMakeRequestWithConfig:
         mock_client = MagicMock()
         mock_client.request.return_value = mock_response
 
-        with patch("httpx.Client") as mock_client_class:
+        with patch("apiconfig.testing.integration.helpers.Client") as mock_client_class:
             # Set up the mock client to return our mock response
             mock_client_instance = mock_client_class.return_value
             mock_client_instance.__enter__.return_value = mock_client
@@ -92,7 +92,7 @@ class TestMakeRequestWithConfig:
         mock_client = MagicMock()
         mock_client.request.return_value = mock_response
 
-        with patch("httpx.Client") as mock_client_class:
+        with patch("apiconfig.testing.integration.helpers.Client") as mock_client_class:
             # Set up the mock client to return our mock response
             mock_client_instance = mock_client_class.return_value
             mock_client_instance.__enter__.return_value = mock_client
@@ -171,7 +171,7 @@ class TestMakeRequestWithConfig:
         ]
 
         for mock_server_url, path, expected_url in test_cases:
-            with patch("httpx.Client") as mock_client_class:
+            with patch("apiconfig.testing.integration.helpers.Client") as mock_client_class:
                 # Reset the mock for each iteration
                 mock_client.reset_mock()
 


### PR DESCRIPTION
## Summary
- import `Client` and `Response` from httpx
- adjust `make_request_with_config` and `simulate_token_endpoint` annotations
- use `Client` when making requests
- update tests to patch the new Client symbol

## Testing
- `pre-commit run --files apiconfig/testing/integration/helpers.py tests/unit/testing/integration/test_helpers.py`
- `poetry run pyright apiconfig/testing/integration/helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68458c4854a08332ad46dd65bb695f5b