### PR TITLE
Add helper client READMEs

### DIFF
--- a/helpers_for_tests/README.md
+++ b/helpers_for_tests/README.md
@@ -1,0 +1,11 @@
+# helpers_for_tests
+
+Example clients used in the test suite. Each submodule contains a minimal API client and configuration helpers built on top of **apiconfig**.
+
+## Available clients
+- [common](common/README.md) – shared `BaseClient` utilities
+- [fiken](fiken/README.md) – Fiken API helpers
+- [oneflow](oneflow/README.md) – OneFlow API helpers
+- [tripletex](tripletex/README.md) – Tripletex API helpers
+
+These modules are for internal testing only. See each README for usage examples and required environment variables.

--- a/helpers_for_tests/fiken/README.md
+++ b/helpers_for_tests/fiken/README.md
@@ -1,0 +1,38 @@
+# helpers_for_tests.fiken
+
+Helper modules for integration tests with the Fiken API.
+
+## Contents
+- `fiken_client.py` – `FikenClient` for basic API calls
+- `fiken_config.py` – configuration helpers (`create_fiken_client_config`, etc.)
+- `__init__.py` – package marker
+
+## Usage example
+```python
+from helpers_for_tests.fiken import create_fiken_client_config, FikenClient
+
+config = create_fiken_client_config()
+client = FikenClient(config)
+companies = client.list_companies()
+```
+
+## Key classes/functions
+| Name | Description |
+| ---- | ----------- |
+| `FikenClient` | Simple client built on `BaseClient` |
+| `create_fiken_client_config` | Build `ClientConfig` using `FIKEN_` environment variables |
+| `create_fiken_config_manager` | `ConfigManager` with defaults and `EnvProvider` |
+| `create_fiken_auth_strategy` | `BearerAuth` using `FIKEN_ACCESS_TOKEN` |
+| `skip_if_no_credentials` | Skip tests if credentials are missing |
+
+### Environment
+Set these variables when running integration tests:
+```bash
+FIKEN_ACCESS_TOKEN=token
+FIKEN_hostname=https://api.fiken.no/api
+FIKEN_version=v2
+FIKEN_timeout=10.0
+```
+
+## Status
+Internal – for example tests only.

--- a/helpers_for_tests/oneflow/README.md
+++ b/helpers_for_tests/oneflow/README.md
@@ -1,0 +1,39 @@
+# helpers_for_tests.oneflow
+
+Utilities for testing integrations with the OneFlow API.
+
+## Contents
+- `oneflow_client.py` – `OneFlowClient` with simple user and contract endpoints
+- `oneflow_config.py` – configuration helpers (`create_oneflow_client_config`, etc.)
+- `__init__.py` – package marker
+
+## Usage example
+```python
+from helpers_for_tests.oneflow import create_oneflow_client_config, OneFlowClient
+
+config = create_oneflow_client_config()
+client = OneFlowClient(config)
+users = client.list_users()
+```
+
+## Key classes/functions
+| Name | Description |
+| ---- | ----------- |
+| `OneFlowClient` | Client built on `BaseClient` |
+| `create_oneflow_client_config` | Build `ClientConfig` using `ONEFLOW_` environment variables |
+| `create_oneflow_config_manager` | `ConfigManager` with defaults and `EnvProvider` |
+| `create_oneflow_auth_strategy` | `ApiKeyAuth` using `ONEFLOW_API_KEY` |
+| `skip_if_no_credentials` | Skip tests if credentials are missing |
+
+### Environment
+Typical environment variables:
+```bash
+ONEFLOW_API_KEY=token
+ONEFLOW_USER_EMAIL=user@example.com
+ONEFLOW_hostname=https://api.test.oneflow.com
+ONEFLOW_version=v1
+ONEFLOW_timeout=10.0
+```
+
+## Status
+Internal – for example tests only.

--- a/helpers_for_tests/tripletex/README.md
+++ b/helpers_for_tests/tripletex/README.md
@@ -1,0 +1,42 @@
+# helpers_for_tests.tripletex
+
+Test helpers for the Tripletex API using apiconfig.
+
+## Contents
+- `tripletex_client.py` – `TripletexClient` with basic endpoints
+- `tripletex_auth.py` – `TripletexSessionAuth` for session token handling
+- `tripletex_config.py` – configuration helpers (`create_tripletex_client_config`, etc.)
+- `__init__.py` – package marker
+
+## Usage example
+```python
+from helpers_for_tests.tripletex import create_tripletex_client_config, TripletexClient
+
+config = create_tripletex_client_config()
+client = TripletexClient(config)
+info = client.get_session_info()
+```
+
+## Key classes/functions
+| Name | Description |
+| ---- | ----------- |
+| `TripletexClient` | Client built on `BaseClient` |
+| `TripletexSessionAuth` | Session-based auth strategy |
+| `create_tripletex_client_config` | Build `ClientConfig` using `TRIPLETEX_TEST_` environment variables |
+| `create_tripletex_config_manager` | `ConfigManager` with defaults and `EnvProvider` |
+| `create_tripletex_auth_strategy` | Helper for constructing `TripletexSessionAuth` |
+| `skip_if_no_credentials` | Skip tests if credentials are missing |
+
+### Environment
+Example environment variables:
+```bash
+TRIPLETEX_TEST_CONSUMER_TOKEN=consumer
+TRIPLETEX_TEST_EMPLOYEE_TOKEN=employee
+TRIPLETEX_TEST_company_id=0
+TRIPLETEX_TEST_hostname=https://api-test.tripletex.tech
+TRIPLETEX_TEST_version=v2
+TRIPLETEX_TEST_timeout=30.0
+```
+
+## Status
+Internal – for example tests only.


### PR DESCRIPTION
## Summary
- document helper clients for Fiken, OneFlow and Tripletex
- add a short overview README under `helpers_for_tests`

## Testing
- `poetry run pre-commit run --files helpers_for_tests/README.md helpers_for_tests/fiken/README.md helpers_for_tests/oneflow/README.md helpers_for_tests/tripletex/README.md`
- `poetry run pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_6845920ca3c08332852ebfc3fe8a8a1b