### PR TITLE
Add README files for documentation folders

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Building the documentation
+
+The documentation is generated with [Sphinx](https://www.sphinx-doc.org/).
+Ensure development dependencies are installed with Poetry and then run:
+
+```bash
+poetry install --with dev
+cd docs
+make html
+```
+
+The HTML output will be available under `docs/build/html/index.html`.

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -1,0 +1,10 @@
+# Documentation Sources
+
+The reStructuredText files in this directory are the sources for the
+Sphinx documentation. Start with `index.rst` which links to the
+installation guide, getting started tutorial and the full user guide.
+The `api/` folder contains the API reference material generated from
+the package modules.
+
+After editing these files, run `make html` from the parent `docs`
+directory to build the HTML documentation.

--- a/docs/source/_static/README.md
+++ b/docs/source/_static/README.md
@@ -1,0 +1,7 @@
+# Static assets
+
+This directory stores files that are copied verbatim into the
+built documentation. Currently it only contains the `css/` folder
+for styling overrides, but images or other assets can also be placed
+here. Organise assets in subdirectories as needed and reference them
+from the documentation sources.

--- a/docs/source/_static/css/README.md
+++ b/docs/source/_static/css/README.md
@@ -1,0 +1,9 @@
+# Custom CSS
+
+The `custom.css` stylesheet tweaks the appearance of the Sphinx
+HTML theme. It improves the readability of code blocks, tables,
+headings and other elements. The file is loaded via the
+`html_static_path` setting in `conf.py`.
+
+Feel free to add more overrides here to adjust the visual style of
+the documentation.

--- a/docs/source/api/README.md
+++ b/docs/source/api/README.md
@@ -1,0 +1,18 @@
+# API Reference
+
+This folder contains the reStructuredText files that make up the
+API reference section of the documentation. Each ``.rst`` file
+corresponds to a module in ``apiconfig`` and is included by
+``index.rst`` to build the full reference guide.
+
+Files include:
+
+- ``auth.rst`` – authentication strategies
+- ``config.rst`` – configuration helpers
+- ``exceptions.rst`` – error hierarchy
+- ``testing.rst`` – utilities for writing tests
+- ``utils.rst`` – small helper functions
+- ``types.rst`` – typed definitions used across the library
+
+When adding new modules, create a matching ``.rst`` file and list it
+in ``index.rst`` so it appears in the generated documentation.


### PR DESCRIPTION
## Summary
- explain how to build Sphinx docs in `docs/README.md`
- describe documentation sources in `docs/source/README.md`
- document API reference layout in `docs/source/api/README.md`
- describe static asset layout and CSS overrides

## Testing
- `pre-commit run --files docs/source/api/README.md docs/source/_static/css/README.md docs/source/_static/README.md docs/source/README.md docs/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6845920da6c8833289887cac3b06d520