### PR TITLE
Add documentation for planning directories

### DIFF
--- a/project_plans/README.md
+++ b/project_plans/README.md
@@ -1,0 +1,11 @@
+# Project Planning
+
+This area houses design documents and task lists for upcoming and finished features. Use these plans to understand the reasoning and steps behind larger changes.
+
+Subdirectories:
+
+- **`finished/`** – completed plans with final implementation notes.
+- **`http_exception_protocol_enhancement/`** – design and report for improving how HTTP exceptions accept protocol objects.
+- **`protocol_typing_fix/`** – investigation and approach to improving protocol typing for external HTTP libraries.
+
+Each folder contains its own README with further details.

--- a/project_plans/finished/README.md
+++ b/project_plans/finished/README.md
@@ -1,0 +1,7 @@
+# Finished Project Plans
+
+This directory collects planning documents for work that has been completed. Each subfolder represents a feature or enhancement that has moved from planning to implementation.
+
+- **`crudclient_integration_implementation/`** – detailed plan for adding authentication refresh and testing utilities used by `crudclient`.
+
+Review the individual folders for full task breakdowns and implementation notes.

--- a/project_plans/finished/crudclient_integration_implementation/tasks/README.md
+++ b/project_plans/finished/crudclient_integration_implementation/tasks/README.md
@@ -1,0 +1,25 @@
+# Task Documents
+
+This folder contains the step-by-step guides for each phase of the CrudClient integration work. Tasks are grouped by implementation phase and provide detailed instructions and completion notes.
+
+## Phase 1 – Core Auth Interface
+- `phase1_task1_type_definitions.md` – Extend `types.py` with token refresh structures.
+- `phase1_task2_auth_strategy_base.md` – Add refresh interface to the base auth strategy.
+- `phase1_task3_bearer_auth_enhancement.md` – Implement bearer token refresh support.
+- `phase1_task4_custom_auth_enhancement.md` – Allow custom auth strategies to define refresh callbacks.
+- `phase1_component_validation.md` – Component tests validating phase 1 features.
+
+## Phase 2 – Testing Enhancement
+- `phase2_task1_auth_verification.md` – Utilities for validating auth headers.
+- `phase2_task2_enhanced_auth_mocks.md` – Improved mocks covering refresh scenarios.
+- `phase2_component_validation.md` – Component tests for the new utilities.
+
+## Phase 3 – Foundation & Polish
+- `phase3_task1_http_context_types.md` – Introduce HTTP context types for errors.
+- `phase3_task2_auth_exception_enhancement.md` – Propagate context through auth exceptions.
+- `phase3_task3_http_api_client_errors.md` – Expand HTTP error hierarchy.
+- `phase3_task4_integration_test_enhancement.md` – Extend integration tests with refresh flows.
+- `phase3_task5_documentation_examples.md` – Final documentation and examples.
+- `phase3_final_validation.md` – End-to-end validation of the completed integration.
+
+Each task lists prerequisites, goals and final status to track progress through the phases.


### PR DESCRIPTION
## Summary
- document project planning hierarchy
- describe finished CrudClient tasks
- add overview of completed planning directory

## Testing
- `pre-commit run --files project_plans/README.md project_plans/finished/README.md project_plans/finished/crudclient_integration_implementation/tasks/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6845920de5048332a8385d7b5ce1d5b7