### PR TITLE
Fix list handling in body redaction

### DIFF
--- a/apiconfig/utils/redaction/body.py
+++ b/apiconfig/utils/redaction/body.py
@@ -29,7 +29,7 @@ def _redact_recursive(
                 redacted_dict[key] = _redact_recursive(value, key_pattern, value_pattern)
         return redacted_dict
     elif isinstance(data, list):
-        typed_list: List[Any] = data
+        typed_list: List[Any] = list(data)
         return [_redact_recursive(item, key_pattern, value_pattern) for item in typed_list]
     elif isinstance(data, str) and value_pattern and value_pattern.search(data):
         return REDACTED_VALUE


### PR DESCRIPTION
## Summary
- fix `_redact_recursive` to copy lists before recursion
- keep explicit type annotations for result variables

## Testing
- `pre-commit run --files apiconfig/utils/redaction/body.py`

------
https://chatgpt.com/codex/tasks/task_e_6845991900008332a0d83745d5f5d370