### PR TITLE
Fix BaseAuthStrategyTest

### DIFF
--- a/apiconfig/testing/unit/helpers.py
+++ b/apiconfig/testing/unit/helpers.py
@@ -182,8 +182,8 @@ class BaseAuthStrategyTest(unittest.TestCase):
         """Ensure subclasses provide a strategy."""
         if cls is BaseAuthStrategyTest:
             return  # Skip setup for the base class itself
-        if not hasattr(cls, "strategy") or not isinstance(cls.strategy, AuthStrategy):
-            raise NotImplementedError(f"{cls.__name__} must define a class attribute 'strategy' " "of type AuthStrategy.")
+        if not hasattr(cls, "strategy"):
+            raise NotImplementedError(f"{cls.__name__} must define a class attribute 'strategy'.")
         check_auth_strategy_interface(cls.strategy)
 
     def assertAuthHeaderCorrect(self, expected_header: str, expected_value: str) -> None:

--- a/tests/unit/testing/unit/test_unit_helpers.py
+++ b/tests/unit/testing/unit/test_unit_helpers.py
@@ -235,7 +235,7 @@ def test_base_auth_strategy_test_setUpClass_wrong_type() -> None:
     class SubTest(helpers.BaseAuthStrategyTest):
         strategy = object()  # type: ignore
 
-    with pytest.raises(NotImplementedError, match="must define a class attribute 'strategy'"):
+    with pytest.raises(AssertionError, match="prepare_request"):
         SubTest.setUpClass()
 
 


### PR DESCRIPTION
## Summary
- simplify the BaseAuthStrategyTest.setUpClass check
- update unit tests to match new logic

## Testing
- `pre-commit run --files apiconfig/testing/unit/helpers.py tests/unit/testing/unit/test_unit_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68459917f2ac8332a6f1077ace0ab3d3