### PR TITLE
Fix urllib.error import in tests

### DIFF
--- a/helpers_for_tests/tripletex/tripletex_auth.py
+++ b/helpers_for_tests/tripletex/tripletex_auth.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import logging
+import urllib.error
 import urllib.parse
 import urllib.request
 from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
## Summary
- prevent pyright error by adding urllib.error import in tripletex test helper

## Testing
- `pre-commit run --files helpers_for_tests/tripletex/tripletex_auth.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845a15733888332b7900a7522191bf2