### PR TITLE
Fix timeout and retries setup in factory

### DIFF
--- a/apiconfig/testing/unit/factories.py
+++ b/apiconfig/testing/unit/factories.py
@@ -20,7 +20,7 @@ def create_valid_client_config(**overrides: Any) -> ClientConfig:
     ClientConfig
         A valid ClientConfig instance.
     """
-    defaults = {
+    defaults: Dict[str, Any] = {
         "hostname": "https://api.example.com",
         "version": "v1",
         "timeout": 30.0,
@@ -48,10 +48,8 @@ def create_valid_client_config(**overrides: Any) -> ClientConfig:
     # Explicitly pass each argument to ClientConfig with correct type
     hostname: str = str(defaults.get("hostname", "https://api.example.com"))
     version: str = str(defaults.get("version", "v1"))
-    timeout_val = cast(float | int | str, defaults.get("timeout", 30.0))
-    timeout: float = float(timeout_val)
-    retries_val = cast(int | float | str, defaults.get("retries", 3))
-    retries: int = int(retries_val)
+    timeout: float = float(defaults.get("timeout", 30.0))
+    retries: int = int(defaults.get("retries", 3))
     headers_val = defaults.get("headers")
     headers: Optional[Dict[str, str]] = cast(Dict[str, str], headers_val) if isinstance(headers_val, dict) else None
     auth_strategy_val = defaults.get("auth_strategy")


### PR DESCRIPTION
## Summary
- remove casts for `timeout` and `retries`
- assign `timeout` via `float()` and `retries` via `int()`

## Testing
- `poetry run pre-commit run --files apiconfig/testing/unit/factories.py`

------
https://chatgpt.com/codex/tasks/task_e_6845b461fab08332b53b7e12958b0b71