### PR TITLE
Fix config creation

### DIFF
--- a/apiconfig/testing/unit/mocks/config.py
+++ b/apiconfig/testing/unit/mocks/config.py
@@ -77,14 +77,13 @@ def create_mock_client_config(
     ClientConfig
         A ClientConfig instance populated with the provided or default values.
     """
-    config_data = {
-        "hostname": hostname,
-        "version": version,
-        "timeout": timeout,
-        "retries": retries,
+    return ClientConfig(
+        hostname=hostname,
+        version=version,
+        timeout=timeout,
+        retries=retries,
         **kwargs,
-    }
-    return ClientConfig(**config_data)
+    )
 
 
 class MockConfigManager(ConfigManager):


### PR DESCRIPTION
## Summary
- remove temporary dict when creating mock client config

## Testing
- `poetry run pre-commit run --files apiconfig/testing/unit/mocks/config.py`

------
https://chatgpt.com/codex/tasks/task_e_6845b46344408332bb1bfb4a73212f33