### PR TITLE
Expose header redaction helpers

### DIFF
--- a/apiconfig/utils/redaction/headers.py
+++ b/apiconfig/utils/redaction/headers.py
@@ -208,3 +208,19 @@ def _redact_set_cookie_header(set_cookie_value: str, sensitive_keys: Set[str]) -
         return f"{redacted_main_cookie}; {attributes}"
     else:
         return redacted_main_cookie
+
+
+# Public aliases for the helper functions
+redact_cookie_header = _redact_cookie_header
+redact_set_cookie_header = _redact_set_cookie_header
+
+
+__all__ = [
+    "DEFAULT_SENSITIVE_HEADERS",
+    "DEFAULT_SENSITIVE_HEADER_PREFIXES",
+    "DEFAULT_SENSITIVE_COOKIE_KEYS",
+    "REDACTED_VALUE",
+    "redact_headers",
+    "redact_cookie_header",
+    "redact_set_cookie_header",
+]

--- a/tests/unit/utils/redaction/test_headers.py
+++ b/tests/unit/utils/redaction/test_headers.py
@@ -8,9 +8,9 @@ from apiconfig.utils.redaction.headers import (
     DEFAULT_SENSITIVE_HEADER_PREFIXES,
     DEFAULT_SENSITIVE_HEADERS,
     REDACTED_VALUE,
-    _redact_cookie_header,
-    _redact_set_cookie_header,
+    redact_cookie_header,
     redact_headers,
+    redact_set_cookie_header,
 )
 
 # Test Cases for redact_headers
@@ -222,8 +222,8 @@ def test_redact_headers_immutable() -> None:
     ],
 )
 def test_redact_cookie_header(cookie_value: str, expected_result: str) -> None:
-    """Tests the _redact_cookie_header function with various inputs."""
-    result = _redact_cookie_header(cookie_value, DEFAULT_SENSITIVE_COOKIE_KEYS)
+    """Tests the redact_cookie_header function with various inputs."""
+    result = redact_cookie_header(cookie_value, DEFAULT_SENSITIVE_COOKIE_KEYS)
     assert result == expected_result
 
 
@@ -271,8 +271,8 @@ def test_redact_cookie_header(cookie_value: str, expected_result: str) -> None:
     ],
 )
 def test_redact_set_cookie_header(set_cookie_value: str, expected_result: str) -> None:
-    """Tests the _redact_set_cookie_header function with various inputs."""
-    result = _redact_set_cookie_header(set_cookie_value, DEFAULT_SENSITIVE_COOKIE_KEYS)
+    """Tests the redact_set_cookie_header function with various inputs."""
+    result = redact_set_cookie_header(set_cookie_value, DEFAULT_SENSITIVE_COOKIE_KEYS)
     assert result == expected_result
 
 
@@ -339,20 +339,20 @@ def test_redact_headers_with_custom_cookie_keys() -> None:
 
 
 def test_redact_cookie_header_with_custom_keys() -> None:
-    """Tests _redact_cookie_header with custom sensitive keys."""
+    """Tests redact_cookie_header with custom sensitive keys."""
     cookie_value = "custom=value; public=ok"
     custom_keys = {"custom"}
     expected_result = "custom=[REDACTED]; public=ok"
 
-    result = _redact_cookie_header(cookie_value, custom_keys)
+    result = redact_cookie_header(cookie_value, custom_keys)
     assert result == expected_result
 
 
 def test_redact_set_cookie_header_with_custom_keys() -> None:
-    """Tests _redact_set_cookie_header with custom sensitive keys."""
+    """Tests redact_set_cookie_header with custom sensitive keys."""
     set_cookie_value = "custom=value; Path=/"
     custom_keys = {"custom"}
     expected_result = "custom=[REDACTED]; Path=/"
 
-    result = _redact_set_cookie_header(set_cookie_value, custom_keys)
+    result = redact_set_cookie_header(set_cookie_value, custom_keys)
     assert result == expected_result


### PR DESCRIPTION
## Summary
- make cookie/set-cookie redaction helpers public in `__all__`
- import helpers by new names in tests

## Testing
- `poetry run pytest -q`
- `poetry run pre-commit run --files apiconfig/utils/redaction/headers.py tests/unit/utils/redaction/test_headers.py`


------
https://chatgpt.com/codex/tasks/task_e_6845b4677c0883329af5000a479330eb