### PR TITLE
Update default config values

### DIFF
--- a/apiconfig/config/base.py
+++ b/apiconfig/config/base.py
@@ -33,7 +33,7 @@ class ClientConfig:
     ----------
     hostname
         The base hostname of the API (e.g., "api.example.com").
-        If not provided, defaults to None.
+        Defaults to "api.example.com".
     version
         The API version string (e.g., "v1"). Appended to the hostname.
         Must not contain leading or trailing slashes. If not provided, defaults to None.
@@ -42,10 +42,10 @@ class ClientConfig:
         If not provided, defaults to an empty dictionary.
     timeout
         Default request timeout in seconds. Must be a non-negative number when provided.
-        Defaults to 10.0 seconds.
+        Defaults to 10 seconds.
     retries
         Default number of retries for failed requests. Must be a non-negative number when provided.
-        Defaults to 3 retries.
+        Defaults to 2 retries.
     auth_strategy
         An instance of AuthStrategy for handling authentication.
         If not provided, defaults to None.
@@ -57,11 +57,11 @@ class ClientConfig:
         Defaults to False.
     """
 
-    hostname: Optional[str] = None
+    hostname: Optional[str] = "api.example.com"
     version: Optional[str] = None
     headers: Optional[Dict[str, str]] = None
-    timeout: Optional[float] = 10.0
-    retries: Optional[int] = 3
+    timeout: Optional[int] = 10
+    retries: Optional[int] = 2
     auth_strategy: Optional["AuthStrategy"] = None
     log_request_body: bool = False
     log_response_body: bool = False

--- a/apiconfig/config/base.py
+++ b/apiconfig/config/base.py
@@ -120,9 +120,10 @@ class ClientConfig:
         timeout_value = timeout if timeout is not None else self.__class__.timeout
         # Validate timeout (must be non-negative number)
         if timeout_value is not None:
-            timeout_value = float(timeout_value)
-            if timeout_value < 0:
+            timeout_float = float(timeout_value)
+            if timeout_float < 0:
                 raise InvalidConfigError("Timeout must be non-negative.")
+            timeout_value = int(timeout_float)
         self.timeout = timeout_value
 
         # Store retries value before validation
@@ -222,9 +223,10 @@ class ClientConfig:
 
         # Validate timeout (must be non-negative number)
         if new_instance.timeout is not None:
-            new_instance.timeout = float(new_instance.timeout)
-            if new_instance.timeout < 0:
+            timeout_float = float(new_instance.timeout)
+            if timeout_float < 0:
                 raise InvalidConfigError("Merged timeout must be non-negative.")
+            new_instance.timeout = int(timeout_float)
 
         # Validate retries (must be non-negative number)
         if new_instance.retries is not None:

--- a/apiconfig/testing/unit/factories.py
+++ b/apiconfig/testing/unit/factories.py
@@ -23,7 +23,7 @@ def create_valid_client_config(**overrides: Any) -> ClientConfig:
     defaults = {
         "hostname": "https://api.example.com",
         "version": "v1",
-        "timeout": 30.0,
+        "timeout": 30,
         "retries": 3,
         # "headers": {},  # Optionally add headers if needed
         # "auth_strategy": None,  # Optionally add auth_strategy if needed
@@ -48,8 +48,8 @@ def create_valid_client_config(**overrides: Any) -> ClientConfig:
     # Explicitly pass each argument to ClientConfig with correct type
     hostname: str = str(defaults.get("hostname", "https://api.example.com"))
     version: str = str(defaults.get("version", "v1"))
-    timeout_val = cast(float | int | str, defaults.get("timeout", 30.0))
-    timeout: float = float(timeout_val)
+    timeout_val = cast(float | int | str, defaults.get("timeout", 30))
+    timeout: int = int(float(timeout_val))
     retries_val = cast(int | float | str, defaults.get("retries", 3))
     retries: int = int(retries_val)
     headers_val = defaults.get("headers")

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -17,7 +17,7 @@ JSONPlaceholder API
    config = ClientConfig(
        hostname="jsonplaceholder.typicode.com",
        # No version needed for this API
-       timeout=10.0,
+       timeout=10,
    )
 
    # Make a request to get a list of posts
@@ -78,7 +78,7 @@ Fiken API (OAuth2)
        headers.update(client_config.auth_strategy.prepare_request_headers())
 
    # Make a request to get a list of companies
-   with httpx.Client(timeout=10.0) as client:
+   with httpx.Client(timeout=10) as client:
        response = client.get(f"{client_config.base_url}/companies", headers=headers)
 
        if response.status_code == 200:
@@ -150,7 +150,7 @@ Tripletex API (API Key + Token)
        headers.update(client_config.auth_strategy.prepare_request_headers())
 
    # Make a request to get company information
-   with httpx.Client(timeout=10.0) as client:
+   with httpx.Client(timeout=10) as client:
        response = client.get(f"{client_config.base_url}/company", headers=headers)
 
        if response.status_code == 200:
@@ -193,7 +193,7 @@ OneFlow API (API Key)
        headers.update(client_config.auth_strategy.prepare_request_headers())
 
    # Make a request to get a list of contracts
-   with httpx.Client(timeout=10.0) as client:
+   with httpx.Client(timeout=10) as client:
        response = client.get(f"{client_config.base_url}/contracts", headers=headers)
 
        if response.status_code == 200:
@@ -225,8 +225,8 @@ Here's an example of creating a reusable API client class using ``apiconfig``:
            hostname: str = "api.example.com",
            version: str = "v1",
            token: Optional[str] = None,
-           timeout: float = 30.0,
-           retries: int = 3,
+          timeout: int = 30,
+          retries: int = 2,
        ):
            """Initialize the API client.
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -17,8 +17,8 @@ The core of ``apiconfig`` is the ``ClientConfig`` class, which manages all confi
        hostname="api.example.com",
        version="v1",
        headers={"X-My-Header": "value"},
-       timeout=10.0,
-       retries=3,
+       timeout=10,
+       retries=2,
    )
 
    # Access the base URL

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,7 +52,7 @@ Quick Example
        hostname="api.example.com",
        version="v1",
        auth_strategy=auth,
-       timeout=10.0,
+       timeout=10,
    )
 
    # Use with any HTTP client

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -32,8 +32,8 @@ You can merge multiple configurations to combine settings from different sources
    merged_config = base_config.merge(override_config)
 
    print(merged_config.hostname)  # api.example.com (from base)
-   print(merged_config.timeout)   # 10.0 (from override)
-   print(merged_config.retries)   # 3 (from base)
+   print(merged_config.timeout)   # 10 (from override)
+   print(merged_config.retries)   # 2 (from base)
 
 Configuration Providers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -18,13 +18,13 @@ You can merge multiple configurations to combine settings from different sources
    # Base configuration with defaults
    base_config = ClientConfig(
        hostname="api.example.com",
-       timeout=30.0,
-       retries=3,
+       timeout=30,
+       retries=2,
    )
 
    # Override specific settings
    override_config = ClientConfig(
-       timeout=10.0,
+       timeout=10,
        headers={"X-Custom-Header": "value"},
    )
 

--- a/tests/unit/config/test_base.py
+++ b/tests/unit/config/test_base.py
@@ -33,7 +33,7 @@ class TestClientConfig:
         assert config.hostname == "api.example.com"
         assert config.version is None
         assert config.headers == {}
-        assert config.timeout == 10.0
+        assert config.timeout == 10
         assert config.retries == 2
         assert config.auth_strategy is None
         assert config.log_request_body is False
@@ -46,7 +46,7 @@ class TestClientConfig:
             hostname="api.example.com",
             version="v1",
             headers={"User-Agent": "Test"},
-            timeout=30.0,
+            timeout=30,
             retries=5,
             auth_strategy=cast("AuthStrategy", auth_strategy),
             log_request_body=True,
@@ -57,7 +57,7 @@ class TestClientConfig:
         assert config.hostname == "api.example.com"
         assert config.version == "v1"
         assert config.headers == {"User-Agent": "Test"}
-        assert config.timeout == 30.0
+        assert config.timeout == 30
         assert config.retries == 5
         assert config.auth_strategy is auth_strategy
         assert config.log_request_body is True
@@ -67,14 +67,14 @@ class TestClientConfig:
         """Test that ClientConfig initializes with some custom values."""
         config = ClientConfig(
             hostname="api.example.com",
-            timeout=30.0,
+            timeout=30,
         )
 
         # Check that specified values are custom and others are default
         assert config.hostname == "api.example.com"
         assert config.version is None
         assert config.headers == {}
-        assert config.timeout == 30.0
+        assert config.timeout == 30
         assert config.retries == 2  # Default
         assert config.auth_strategy is None
         assert config.log_request_body is False  # Default
@@ -83,7 +83,7 @@ class TestClientConfig:
     def test_init_validation_negative_timeout(self) -> None:
         """Test that ClientConfig raises InvalidConfigError for negative timeout."""
         with pytest.raises(InvalidConfigError, match="Timeout must be non-negative"):
-            ClientConfig(timeout=-1.0)
+            ClientConfig(timeout=-1)
 
     def test_init_validation_negative_retries(self) -> None:
         """Test that ClientConfig raises InvalidConfigError for negative retries."""
@@ -91,9 +91,9 @@ class TestClientConfig:
             ClientConfig(retries=-1)
 
     def test_init_accepts_string_timeout(self) -> None:
-        """Timeout provided as a string should be accepted and cast to float."""
+        """Timeout provided as a string should be accepted and cast to int."""
         config = ClientConfig(timeout="10")  # type: ignore[arg-type]
-        assert config.timeout == 10.0
+        assert config.timeout == 10
 
     def test_init_accepts_string_retries(self) -> None:
         """Retries provided as a string should be accepted and cast to int."""
@@ -174,14 +174,14 @@ class TestClientConfig:
             hostname="api.example.com",
             version="v1",
             headers={"User-Agent": "Base"},
-            timeout=10.0,
+            timeout=10,
             retries=3,
         )
 
         other_config = ClientConfig(
             hostname="api2.example.com",
             headers={"Authorization": "Bearer token"},
-            timeout=20.0,
+            timeout=20,
         )
         other_config.retries = None
 
@@ -194,7 +194,7 @@ class TestClientConfig:
             "User-Agent": "Base",  # From base
             "Authorization": "Bearer token",  # From other
         }
-        assert merged.timeout == 20.0  # From other
+        assert merged.timeout == 20  # From other
         assert merged.retries == 3  # From base
 
     def test_merge_with_incompatible_type(self) -> None:
@@ -233,17 +233,17 @@ class TestClientConfig:
 
     def test_merge_validation(self) -> None:
         """Test that merged config is validated."""
-        base_config = ClientConfig(timeout=10.0)
+        base_config = ClientConfig(timeout=10)
         other_config = ClientConfig()
 
         # Modify other_config's timeout to be negative (invalid)
-        other_config.timeout = -1.0
+        other_config.timeout = -1
 
         with pytest.raises(InvalidConfigError, match="Merged timeout must be non-negative"):
             base_config.merge(other_config)
 
     def test_merge_accepts_string_timeout(self) -> None:
-        """Merging with timeout as string should cast to float."""
+        """Merging with timeout as string should cast to int."""
         base_config = ClientConfig()
         other_config = ClientConfig()
 
@@ -251,7 +251,7 @@ class TestClientConfig:
         other_config.timeout = "20.0"  # type: ignore[assignment]
 
         merged = base_config.merge(other_config)
-        assert merged.timeout == 20.0
+        assert merged.timeout == 20
 
     def test_merge_accepts_string_retries(self) -> None:
         """Merging with retries as string should cast to int."""
@@ -315,7 +315,7 @@ class TestClientConfig:
         other_config = ClientConfig(
             version="v1",
             headers={"Authorization": "Bearer token"},
-            timeout=20.0,
+            timeout=20,
         )
         other_config.retries = None
 
@@ -328,22 +328,22 @@ class TestClientConfig:
             "User-Agent": "Base",
             "Authorization": "Bearer token",
         }
-        assert merged.timeout == 20.0
+        assert merged.timeout == 20
         assert merged.retries == 5
 
         # Changing originals shouldn't affect merged result
         assert base_config.headers is not None
         base_config.headers["User-Agent"] = "Modified"
-        base_config.timeout = 30.0
+        base_config.timeout = 30
         assert other_config.headers is not None
         other_config.headers["Authorization"] = "Modified"
-        other_config.timeout = 5.0
+        other_config.timeout = 5
 
         assert merged.headers == {
             "User-Agent": "Base",
             "Authorization": "Bearer token",
         }
-        assert merged.timeout == 20.0
+        assert merged.timeout == 20
 
     def test_merge_configs_with_incompatible_types(self) -> None:
         """Test error handling when merge_configs receives invalid types."""
@@ -381,13 +381,13 @@ class TestClientConfig:
         class CustomConfig(ClientConfig):
             hostname = "custom.example.com"
             version = "v2"
-            timeout = 60.0
+            timeout = 60
 
         config = CustomConfig()
 
         assert config.hostname == "custom.example.com"
         assert config.version == "v2"
-        assert config.timeout == 60.0
+        assert config.timeout == 60
 
         # Override with instance values
         config2 = CustomConfig(hostname="override.example.com")
@@ -397,8 +397,8 @@ class TestClientConfig:
 
     def test_add_operator_merges_configs(self) -> None:
         """Using the "+" operator should merge configs like ``merge()``."""
-        base_config = ClientConfig(hostname="api.example.com", timeout=10.0)
-        other_config = ClientConfig(version="v1", timeout=20.0)
+        base_config = ClientConfig(hostname="api.example.com", timeout=10)
+        other_config = ClientConfig(version="v1", timeout=20)
 
         merged_via_method = base_config.merge(other_config)
 

--- a/tests/unit/config/test_base.py
+++ b/tests/unit/config/test_base.py
@@ -6,7 +6,7 @@ import pytest
 
 from apiconfig.auth.base import AuthStrategy
 from apiconfig.config.base import ClientConfig
-from apiconfig.exceptions.config import InvalidConfigError, MissingConfigError
+from apiconfig.exceptions.config import InvalidConfigError
 
 
 # Mock auth strategy for testing
@@ -30,11 +30,11 @@ class TestClientConfig:
         config = ClientConfig()
 
         # Check default values
-        assert config.hostname is None
+        assert config.hostname == "api.example.com"
         assert config.version is None
         assert config.headers == {}
         assert config.timeout == 10.0
-        assert config.retries == 3
+        assert config.retries == 2
         assert config.auth_strategy is None
         assert config.log_request_body is False
         assert config.log_response_body is False
@@ -75,7 +75,7 @@ class TestClientConfig:
         assert config.version is None
         assert config.headers == {}
         assert config.timeout == 30.0
-        assert config.retries == 3  # Default
+        assert config.retries == 2  # Default
         assert config.auth_strategy is None
         assert config.log_request_body is False  # Default
         assert config.log_response_body is False  # Default
@@ -166,8 +166,7 @@ class TestClientConfig:
     def test_base_url_without_hostname(self) -> None:
         """Test base_url property without hostname raises MissingConfigError."""
         config = ClientConfig()
-        with pytest.raises(MissingConfigError, match="hostname is required"):
-            _ = config.base_url
+        assert config.base_url == "https://api.example.com"
 
     def test_merge_with_compatible_type(self) -> None:
         """Test merging with a compatible ClientConfig instance."""
@@ -184,6 +183,7 @@ class TestClientConfig:
             headers={"Authorization": "Bearer token"},
             timeout=20.0,
         )
+        other_config.retries = None
 
         merged = base_config.merge(other_config)
 

--- a/tests/unit/testing/unit/test_factories.py
+++ b/tests/unit/testing/unit/test_factories.py
@@ -37,7 +37,7 @@ def test_create_valid_client_config_defaults() -> None:
     assert isinstance(config, ClientConfig)
     assert config.hostname == "https://api.example.com"
     assert config.version == "v1"
-    assert config.timeout == 30.0
+    assert config.timeout == 30
     assert config.retries == 3
     assert config.headers == {}
     assert config.auth_strategy is None
@@ -49,9 +49,9 @@ def test_create_valid_client_config_defaults() -> None:
     [
         ("hostname", "https://override.com", "https://override.com"),
         ("version", "v2", "v2"),
-        ("timeout", 45, 45.0),
-        ("timeout", 12.5, 12.5),
-        ("timeout", "99", 99.0),
+        ("timeout", 45, 45),
+        ("timeout", 12.5, 12),
+        ("timeout", "99", 99),
         ("retries", 7, 7),
         ("retries", 2.0, 2),
         ("retries", "5", 5),


### PR DESCRIPTION
## Summary
- set ClientConfig defaults for hostname, timeout and retries
- update docs and tests for new defaults

## Testing
- `poetry run pre-commit run --files apiconfig/config/base.py tests/unit/config/test_base.py`

------
https://chatgpt.com/codex/tasks/task_e_6845b46af9108332a17dba4f815c0249