### PR TITLE
Fix pyright private import warnings in tests

### DIFF
--- a/tests/unit/auth/token/test_refresh_helpers.py
+++ b/tests/unit/auth/token/test_refresh_helpers.py
@@ -2,10 +2,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
+# isort: off
 from apiconfig.auth.token.refresh import (
-    _get_effective_settings,
-    _prepare_auth_and_payload,
+    _get_effective_settings,  # pyright: ignore[reportPrivateUsage]
+    _prepare_auth_and_payload,  # pyright: ignore[reportPrivateUsage]
 )
+
+# isort: on
 from apiconfig.config.base import ClientConfig
 
 


### PR DESCRIPTION
## Summary
- silence pyright private usage warnings for refresh helper imports in tests
- keep formatting stable by disabling isort around the import

## Testing
- `pre-commit run --files tests/unit/auth/token/test_refresh_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_6845b46c03208332ac7da33bfc32f746