### PR TITLE
Fix class-level annotations in test helpers

### DIFF
--- a/apiconfig/testing/unit/helpers.py
+++ b/apiconfig/testing/unit/helpers.py
@@ -4,7 +4,7 @@ import contextlib
 import os
 import tempfile
 import unittest
-from typing import Any, Dict, Generator, Optional, Protocol, Type
+from typing import Any, ClassVar, Dict, Generator, Optional, Protocol, Type
 
 from apiconfig.auth.base import AuthStrategy
 
@@ -207,10 +207,10 @@ class BaseConfigProviderTest(unittest.TestCase):
     Provides helper context managers for temporary environments.
     """
 
-    provider_class: Optional[Type[ConfigProviderProtocol]] = None
-    required_env_vars: Optional[Dict[str, str]] = None
-    config_content: Optional[str] = None
-    config_suffix: str = ".tmp"
+    provider_class: ClassVar[Optional[Type[ConfigProviderProtocol]]] = None
+    required_env_vars: ClassVar[Optional[Dict[str, str]]] = None
+    config_content: ClassVar[Optional[str]] = None
+    config_suffix: ClassVar[str] = ".tmp"
 
     def get_provider_instance(self, *args: Any, **kwargs: Any) -> ConfigProviderProtocol:
         """


### PR DESCRIPTION
## Summary
- use `ClassVar` for config provider test attributes

## Testing
- `pre-commit run --files apiconfig/testing/unit/helpers.py`
- `pre-commit run -a` *(fails: docstrings missing type annotations)*

------
https://chatgpt.com/codex/tasks/task_e_6845dd39a2348332ac6c8c01a9eada66