### PR TITLE
Fix pyright warning in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,7 +65,7 @@ myst_enable_extensions = [
 myst_heading_anchors = 3  # Auto-generate heading anchors up to level 3
 
 templates_path = ["_templates"]
-exclude_patterns = []
+exclude_patterns: list[str] = []
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
## Summary
- type hint `exclude_patterns` in docs

## Testing
- `pre-commit run --files docs/source/conf.py`
- `poetry run pyright docs/source/conf.py`


------
https://chatgpt.com/codex/tasks/task_e_6845dd3749c88332b852ea33b3865b27