### PR TITLE
Expose logging test helpers

### DIFF
--- a/apiconfig/utils/logging/formatters/__init__.py
+++ b/apiconfig/utils/logging/formatters/__init__.py
@@ -10,7 +10,11 @@ from apiconfig.utils.redaction.headers import (
 )
 
 from .detailed import DetailedFormatter
-from .redacting import RedactingFormatter
+from .redacting import (
+    RedactingFormatter,
+    redact_message_helper,
+    redact_structured_helper,
+)
 
 __all__: tuple[str, ...] = (
     "DetailedFormatter",
@@ -20,4 +24,6 @@ __all__: tuple[str, ...] = (
     "REDACTED_VALUE",
     "DEFAULT_SENSITIVE_HEADERS",
     "DEFAULT_SENSITIVE_HEADER_PREFIXES",
+    "redact_message_helper",
+    "redact_structured_helper",
 )

--- a/apiconfig/utils/logging/formatters/redacting.py
+++ b/apiconfig/utils/logging/formatters/redacting.py
@@ -270,3 +270,13 @@ class RedactingFormatter(logging.Formatter):
             if "[REDACTED]" in redacted:
                 return redacted
         return msg
+
+
+def redact_structured_helper(formatter: "RedactingFormatter", msg: Any, content_type: Any) -> str:
+    """Public helper to call ``RedactingFormatter._redact_structured`` for tests."""
+    return formatter._redact_structured(msg, content_type)
+
+
+def redact_message_helper(formatter: "RedactingFormatter", record: logging.LogRecord) -> None:
+    """Public helper to call ``RedactingFormatter._redact_message`` for tests."""
+    formatter._redact_message(record)


### PR DESCRIPTION
## Summary
- add public helpers in redacting formatter module
- expose helpers in logging formatter package
- update redacting formatter tests to use public helpers

## Testing
- `pre-commit run --files apiconfig/utils/logging/formatters/redacting.py apiconfig/utils/logging/formatters/__init__.py tests/unit/utils/logging/formatters/test_redacting.py`
- `pytest tests/unit/utils/logging/formatters/test_redacting.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dd36ad28833294a2183a9cab7bcd