### PR TITLE
Improve safety checks in token refresh tests

### DIFF
--- a/tests/component/test_end_to_end_refresh.py
+++ b/tests/component/test_end_to_end_refresh.py
@@ -73,8 +73,8 @@ class TestEndToEndRefresh:
 
         token_data = result["token_data"]
         assert token_data is not None
-        assert token_data["access_token"] == "new_access_token"
-        assert token_data["refresh_token"] == "new_refresh_token"
+        assert token_data.get("access_token") == "new_access_token"
+        assert token_data.get("refresh_token") == "new_refresh_token"
 
         # Verify internal state updated
         assert auth.access_token == "new_access_token"
@@ -104,7 +104,7 @@ class TestEndToEndRefresh:
         assert result is not None
         token_data = result["token_data"]
         assert token_data is not None
-        assert token_data["access_token"] == "new_token"
+        assert token_data.get("access_token") == "new_token"
 
         headers = auth.prepare_request_headers()
         assert headers["Authorization"] == "Bearer new_token"

--- a/tests/component/test_existing_component_integration.py
+++ b/tests/component/test_existing_component_integration.py
@@ -57,8 +57,8 @@ class TestExistingComponentIntegration:
         token_data = result["token_data"]
         assert token_data is not None
         updated_token_data = {
-            "access_token": token_data["access_token"],
-            "refresh_token": token_data["refresh_token"],
+            "access_token": token_data.get("access_token"),
+            "refresh_token": token_data.get("refresh_token"),
             "expires_at": "2024-12-31T23:59:59Z",  # Would be calculated from expires_in
         }
         storage.store_token("test_key", updated_token_data)
@@ -137,7 +137,7 @@ class TestExistingComponentIntegration:
         assert result is not None
         token_data = result["token_data"]
         assert token_data is not None
-        assert token_data["access_token"] == "refreshed_api_key"
+        assert token_data.get("access_token") == "refreshed_api_key"
 
         # Verify storage was updated
         updated_data = storage.retrieve_token("custom_key")

--- a/tests/component/test_phase2_cross_component_integration.py
+++ b/tests/component/test_phase2_cross_component_integration.py
@@ -231,6 +231,7 @@ class TestPhase2CrossComponentIntegration:
         token_data = response.json()
 
         # Create mock auth with the received token
+        assert "access_token" in token_data
         mock_auth = MockBearerAuthWithRefresh(initial_token=token_data["access_token"])
         headers: Dict[str, str] = {}
         mock_auth.apply_auth(headers)

--- a/tests/component/test_refresh_performance.py
+++ b/tests/component/test_refresh_performance.py
@@ -79,7 +79,7 @@ class TestRefreshPerformance:
         assert result is not None
         token_data = result["token_data"]
         assert token_data is not None
-        assert token_data["access_token"] == "new_token_1"
+        assert token_data.get("access_token") == "new_token_1"
 
     def test_multiple_refresh_operations(self) -> None:
         """Test performance of multiple refresh operations."""

--- a/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
+++ b/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
@@ -99,10 +99,10 @@ class TestMockRefreshableAuthStrategy:
         assert result is not None
         assert result["token_data"] is not None
         token_data = result["token_data"]
-        assert token_data["access_token"] == "initial_refreshed_1"
-        assert token_data["refresh_token"] == "refresh_token_new"
-        assert token_data["expires_in"] == 3600
-        assert token_data["token_type"] == "Bearer"
+        assert token_data.get("access_token") == "initial_refreshed_1"
+        assert token_data.get("refresh_token") == "refresh_token_new"
+        assert token_data.get("expires_in") == 3600
+        assert token_data.get("token_type") == "Bearer"
         assert result["config_updates"] is None
         assert strategy.current_token == "initial_refreshed_1"
         assert strategy._refresh_attempts == 1


### PR DESCRIPTION
## Summary
- ensure component refresh tests use `.get` or existence assertions before indexing
- adjust token data updates to use `.get` access

## Testing
- `pre-commit run --files tests/component/test_end_to_end_refresh.py tests/component/test_refresh_performance.py tests/component/test_existing_component_integration.py tests/component/test_phase2_cross_component_integration.py tests/unit/testing/mocks/test_enhanced_auth_mocks.py`

------
https://chatgpt.com/codex/tasks/task_e_6845dd35d800833286f1153d5fb1b776