### PR TITLE
Fix OneFlow headers typing

### DIFF
--- a/helpers_for_tests/oneflow/oneflow_config.py
+++ b/helpers_for_tests/oneflow/oneflow_config.py
@@ -94,7 +94,7 @@ def create_oneflow_client_config() -> ClientConfig:
         pytest.skip(f"Invalid timeout value in ONEFLOW_timeout: {e}")
 
     # Handle user email header if provided
-    headers = {}
+    headers: dict[str, str] = {}
     user_email = config.get("USER_EMAIL")
     if user_email:
         headers["x-oneflow-user-email"] = user_email


### PR DESCRIPTION
## Summary
- annotate headers mapping as `dict[str, str]`

## Testing
- `poetry run pre-commit run --files helpers_for_tests/oneflow/oneflow_config.py`
- `poetry run mypy helpers_for_tests/oneflow/oneflow_config.py`
- `poetry run pyright helpers_for_tests/oneflow/oneflow_config.py` *(fails: Unnecessary `# type: ignore` comment)*
- `poetry run flake8 helpers_for_tests/oneflow/oneflow_config.py`
- `poetry run black --check helpers_for_tests/oneflow/oneflow_config.py`
- `poetry run isort --check helpers_for_tests/oneflow/oneflow_config.py`
- `poetry run pytest tests/integration/test_apiconfig_oneflow.py::TestOneFlowIntegration::test_oneflow_apiconfig_setup -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dd33f2ac8332aa1ec1054c1e6fca