### PR TITLE
Fix return type annotation

### DIFF
--- a/helpers_for_tests/common/base_client.py
+++ b/helpers_for_tests/common/base_client.py
@@ -188,7 +188,8 @@ class BaseClient:
                     json=json_data if json_data is not None else None,
                     **kwargs,
                 )
-                return self._handle_response(response, method, url)
+                result: Union[JsonObject, JsonList] = self._handle_response(response, method, url)
+                return result
 
         except RequestError as e:
             raise HTTPUtilsError(f"Request failed for {method.value} {url}: {e}") from e


### PR DESCRIPTION
## Summary
- ensure `_request` uses typed variable `result`

## Testing
- `pre-commit run --files helpers_for_tests/common/base_client.py`
- `pre-commit run --hook-stage pre-push --files helpers_for_tests/common/base_client.py` *(fails: InterpreterNotFound python3.13)*

------
https://chatgpt.com/codex/tasks/task_e_6845dd3309008332b7131fe66d826ec0