### PR TITLE
Fix file provider type return

### DIFF
--- a/apiconfig/config/providers/file.py
+++ b/apiconfig/config/providers/file.py
@@ -152,6 +152,6 @@ class FileProvider:
                         raise ValueError(f"Cannot convert '{value}' to bool")
                 except AttributeError:
                     return bool(value)
-            return expected_type(value)  # type: ignore[call-arg]
+            return cast(T, expected_type(value))  # type: ignore[call-arg,redundant-cast]
         except (ValueError, TypeError) as e:
             raise ConfigValueError(f"Cannot convert configuration value for '{key}' ({value}) to {expected_type.__name__}: {str(e)}") from e


### PR DESCRIPTION
## Summary
- ensure `FileProvider.get` return is cast to `T`

## Testing
- `poetry run pre-commit run --files apiconfig/config/providers/file.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684902b73f208332a58bad84db17fec7