### PR TITLE
feat: add TokenData type for token storage

### DIFF
--- a/apiconfig/auth/token/storage.py
+++ b/apiconfig/auth/token/storage.py
@@ -1,7 +1,9 @@
 """Abstract base classes and in-memory implementation for token storage."""
 
 import abc
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
+
+from ...types import TokenData
 
 
 class TokenStorage(abc.ABC):
@@ -13,7 +15,7 @@ class TokenStorage(abc.ABC):
     """
 
     @abc.abstractmethod
-    def store_token(self, key: str, token_data: Any) -> None:
+    def store_token(self, key: str, token_data: TokenData) -> None:
         """
         Store token data associated with a key.
 
@@ -21,13 +23,14 @@ class TokenStorage(abc.ABC):
         ----------
         key : str
             The unique identifier for the token.
-        token_data : Any
-            The token data to store (e.g., a string, dictionary).
+        token_data : TokenData
+            The token data to store, typically containing fields like
+            ``access_token`` and ``refresh_token``.
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def retrieve_token(self, key: str) -> Optional[Any]:
+    def retrieve_token(self, key: str) -> Optional[TokenData]:
         """
         Retrieve token data associated with a key.
 
@@ -38,7 +41,7 @@ class TokenStorage(abc.ABC):
 
         Returns
         -------
-        Optional[Any]
+        Optional[TokenData]
             The stored token data, or None if the key is not found.
         """
         raise NotImplementedError
@@ -64,13 +67,13 @@ class InMemoryTokenStorage(TokenStorage):
     instance terminates. Suitable for testing or short-lived processes.
     """
 
-    _storage: Dict[str, Any]
+    _storage: Dict[str, TokenData]
 
     def __init__(self) -> None:
         """Initialize the in-memory storage dictionary."""
-        self._storage: Dict[str, Any] = {}
+        self._storage: Dict[str, TokenData] = {}
 
-    def store_token(self, key: str, token_data: Any) -> None:
+    def store_token(self, key: str, token_data: TokenData) -> None:
         """
         Store token data in the internal dictionary.
 
@@ -78,12 +81,12 @@ class InMemoryTokenStorage(TokenStorage):
         ----------
         key : str
             The unique identifier for the token.
-        token_data : Any
+        token_data : TokenData
             The token data to store.
         """
         self._storage[key] = token_data
 
-    def retrieve_token(self, key: str) -> Optional[Any]:
+    def retrieve_token(self, key: str) -> Optional[TokenData]:
         """
         Retrieve token data from the internal dictionary.
 
@@ -94,7 +97,7 @@ class InMemoryTokenStorage(TokenStorage):
 
         Returns
         -------
-        Optional[Any]
+        Optional[TokenData]
             The stored token data, or None if the key is not found.
         """
         return self._storage.get(key)

--- a/apiconfig/types.py
+++ b/apiconfig/types.py
@@ -112,6 +112,16 @@ AuthCredentials: TypeAlias = Any
 TokenStorageStrategy: TypeAlias = Any
 """Placeholder type alias for token storage strategy implementations."""
 
+# Data structure for persisted authentication tokens
+TokenData: TypeAlias = Dict[str, Any]
+"""Dictionary structure for stored authentication tokens.
+
+This alias represents the data saved by :class:`apiconfig.auth.token.storage.TokenStorage`
+implementations. Typical keys include ``access_token`` and ``refresh_token``,
+along with optional metadata such as ``expires_at``. Implementations may store
+additional fields as required by their authentication workflows.
+"""
+
 TokenRefreshCallable: TypeAlias = Callable[..., Any]
 """Placeholder type alias for token refresh logic callables."""
 
@@ -248,6 +258,7 @@ __all__ = [
     "ConfigProviderCallable",
     "AuthCredentials",
     "TokenStorageStrategy",
+    "TokenData",
     "TokenRefreshCallable",
     "RefreshedTokenData",
     "TokenRefreshResult",

--- a/tests/unit/auth/token/test_storage.py
+++ b/tests/unit/auth/token/test_storage.py
@@ -30,12 +30,12 @@ class TestInMemoryTokenStorage:
     def test_store_token(self) -> None:
         """Test storing a token."""
         storage = InMemoryTokenStorage()
-        storage.store_token("test_key", "test_token")
-        assert storage._storage["test_key"] == "test_token"
+        storage.store_token("test_key", {"access_token": "test_token"})
+        assert storage._storage["test_key"] == {"access_token": "test_token"}
 
         # Test overwriting an existing token
-        storage.store_token("test_key", "new_token")
-        assert storage._storage["test_key"] == "new_token"
+        storage.store_token("test_key", {"access_token": "new_token"})
+        assert storage._storage["test_key"] == {"access_token": "new_token"}
 
     def test_retrieve_token(self) -> None:
         """Test retrieving a token."""
@@ -45,8 +45,8 @@ class TestInMemoryTokenStorage:
         assert storage.retrieve_token("non_existent") is None
 
         # Test retrieving an existing token
-        storage.store_token("test_key", "test_token")
-        assert storage.retrieve_token("test_key") == "test_token"
+        storage.store_token("test_key", {"access_token": "test_token"})
+        assert storage.retrieve_token("test_key") == {"access_token": "test_token"}
 
     def test_delete_token(self) -> None:
         """Test deleting a token."""
@@ -56,7 +56,7 @@ class TestInMemoryTokenStorage:
         storage.delete_token("non_existent")
 
         # Test deleting an existing token
-        storage.store_token("test_key", "test_token")
+        storage.store_token("test_key", {"access_token": "test_token"})
         assert "test_key" in storage._storage
         storage.delete_token("test_key")
         assert "test_key" not in storage._storage


### PR DESCRIPTION
## Summary
- create TokenData type alias in types
- update TokenStorage and InMemoryTokenStorage to use TokenData

## Testing
- `poetry run pre-commit run --files apiconfig/types.py apiconfig/auth/token/storage.py`

------
https://chatgpt.com/codex/tasks/task_e_684902b11ba883328e1229fcc252dcc8