### PR TITLE
Add generics to ConfigManager protocols

### DIFF
--- a/apiconfig/config/manager.py
+++ b/apiconfig/config/manager.py
@@ -1,31 +1,43 @@
 """Manages loading configuration from multiple providers."""
 
 import logging
-from typing import Any, Dict, Mapping, Protocol, Sequence, runtime_checkable
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Mapping,
+    Protocol,
+    Sequence,
+    TypeAlias,
+    TypeVar,
+    runtime_checkable,
+)
 
 from apiconfig.exceptions.config import ConfigLoadError
 
+_TConfig = TypeVar("_TConfig", bound=Mapping[str, Any], covariant=True)
+
 
 @runtime_checkable
-class _SupportsLoad(Protocol):
+class _SupportsLoad(Protocol[_TConfig]):
     """Protocol for providers implementing ``load``."""
 
-    def load(self) -> Mapping[str, Any]: ...
+    def load(self) -> _TConfig: ...
 
 
 @runtime_checkable
-class _SupportsGetConfig(Protocol):
+class _SupportsGetConfig(Protocol[_TConfig]):
     """Protocol for providers implementing ``get_config``."""
 
-    def get_config(self) -> Mapping[str, Any]: ...
+    def get_config(self) -> _TConfig: ...
 
 
-ConfigProvider = _SupportsLoad | _SupportsGetConfig
+ConfigProvider: TypeAlias = _SupportsLoad[_TConfig] | _SupportsGetConfig[_TConfig]
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-class ConfigManager:
+class ConfigManager(Generic[_TConfig]):
     """
     Manages loading configuration from multiple providers.
 
@@ -44,7 +56,7 @@ class ConfigManager:
     returns a dictionary of configuration values.
     """
 
-    def __init__(self, providers: Sequence[ConfigProvider]) -> None:
+    def __init__(self, providers: Sequence[ConfigProvider[_TConfig]]) -> None:
         """
         Initialize the ConfigManager with a sequence of configuration providers.
 


### PR DESCRIPTION
## Summary
- add `_TConfig` type variable with covariance
- parameterize `_SupportsLoad` and `_SupportsGetConfig` using `_TConfig`
- update `ConfigProvider` alias and make `ConfigManager` generic

## Testing
- `pre-commit run --files apiconfig/config/manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684902b09d348332a72a54e16861d279