### PR TITLE
Add http utils type stubs

### DIFF
--- a/apiconfig/utils/http.pyi
+++ b/apiconfig/utils/http.pyi
@@ -1,11 +1,9 @@
 from typing import Any, Dict, Mapping, Optional, Union
 
-from apiconfig.exceptions.http import (
-    HTTPUtilsError as HTTPUtilsError,
-    JSONDecodeError as JSONDecodeError,
-    JSONEncodeError as JSONEncodeError,
-    PayloadTooLargeError as PayloadTooLargeError,
-)
+from apiconfig.exceptions.http import HTTPUtilsError as HTTPUtilsError
+from apiconfig.exceptions.http import JSONDecodeError as JSONDecodeError
+from apiconfig.exceptions.http import JSONEncodeError as JSONEncodeError
+from apiconfig.exceptions.http import PayloadTooLargeError as PayloadTooLargeError
 
 __all__: list[str]
 


### PR DESCRIPTION
## Summary
- provide `apiconfig.utils.http` stubs with error classes and function signatures

## Testing
- `poetry run pre-commit run --files apiconfig/utils/http.pyi`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684902afd2548332a7fa28567a48d0be