### PR TITLE
Update MockConfigManager signature

### DIFF
--- a/apiconfig/testing/unit/mocks/README.md
+++ b/apiconfig/testing/unit/mocks/README.md
@@ -39,7 +39,7 @@ headers, params = auth.prepare_request()
 | `MockRefreshableAuthStrategy` | Adds refresh behaviour and helpers for testing concurrent refresh scenarios. |
 | `MockHttpRequestCallable` | Callable returning dummy HTTP responses for token refresh tests. |
 | `MockConfigProvider` | Duck-typed provider returning a predefined dictionary. |
-| `MockConfigManager` | Subclass of `ConfigManager` with a `load_config_mock` `MagicMock` invoked by `load_config()`. |
+| `MockConfigManager` | Simple config manager with a `load_config_mock` `MagicMock` invoked by `load_config()`. |
 
 ### Design
 The mocks follow a minimal design where behaviour is simulated through simple

--- a/apiconfig/testing/unit/mocks/config.py
+++ b/apiconfig/testing/unit/mocks/config.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, Optional, cast
 from unittest.mock import MagicMock
 
 from apiconfig.config.base import ClientConfig
-from apiconfig.config.manager import ConfigManager
 
 # NOTE: No ConfigProvider base class found in current implementation.
 # Providers seem to use duck typing (requiring a load() method).
@@ -86,7 +85,7 @@ def create_mock_client_config(
     )
 
 
-class MockConfigManager(ConfigManager):
+class MockConfigManager:
     """
     A mock ConfigManager for testing configuration loading logic.
 
@@ -133,7 +132,7 @@ class MockConfigManager(ConfigManager):
             mock_provider = MagicMock()
             mock_provider.load.return_value = {}
             providers = [mock_provider]
-        super().__init__(providers=providers)
+        self._providers: list[Any] = list(providers)
 
         # Allow predefining the config to be returned by load_config
         self._mock_config = mock_config
@@ -144,6 +143,6 @@ class MockConfigManager(ConfigManager):
             default_config = create_mock_client_config()
         self.load_config_mock = MagicMock(return_value=default_config)
 
-    def load_config(self, *args: Any, **kwargs: Any) -> ClientConfig:  # type: ignore[override]
+    def load_config(self) -> ClientConfig:
         """Return configuration using the underlying MagicMock."""
-        return cast(ClientConfig, self.load_config_mock(*args, **kwargs))
+        return cast(ClientConfig, self.load_config_mock())

--- a/tests/unit/testing/unit/mocks/test_config.py
+++ b/tests/unit/testing/unit/mocks/test_config.py
@@ -176,10 +176,10 @@ class TestMockConfigManager:
         # Reset the mock to clear the call history
         manager.load_config_mock.reset_mock()
 
-        # Call with arguments and verify they were passed
-        manager.load_config(arg1="test", arg2=123)
-        # Use assert_called_once_with to ensure it was called exactly once with these args
-        manager.load_config_mock.assert_called_once_with(arg1="test", arg2=123)
+        # Call again and verify the mock was called a second time without arguments
+        manager.load_config()
+        # Use assert_called_once_with to ensure it was called exactly once with no args
+        manager.load_config_mock.assert_called_once_with()
 
     def test_load_config_with_custom_return_value(self) -> None:
         """Test setting a custom return value for load_config."""


### PR DESCRIPTION
## Summary
- remove inheritance from `ConfigManager`
- adjust `load_config` signature and usage
- update docs and tests for the new API

## Testing
- `pre-commit run --files apiconfig/testing/unit/mocks/config.py tests/unit/testing/unit/mocks/test_config.py apiconfig/testing/unit/mocks/README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684902ad75d483329bb3feb7a5da91a0