### PR TITLE
Export redaction helpers

### DIFF
--- a/apiconfig/utils/logging/formatters/redacting.py
+++ b/apiconfig/utils/logging/formatters/redacting.py
@@ -272,11 +272,18 @@ class RedactingFormatter(logging.Formatter):
         return msg
 
 
-def redact_structured_helper(formatter: "RedactingFormatter", msg: Any, content_type: Any) -> str:
+def redact_structured_helper(formatter: RedactingFormatter, msg: Any, content_type: Any) -> str:
     """Public helper to call ``RedactingFormatter._redact_structured`` for tests."""
     return formatter._redact_structured(msg, content_type)
 
 
-def redact_message_helper(formatter: "RedactingFormatter", record: logging.LogRecord) -> None:
+def redact_message_helper(formatter: RedactingFormatter, record: logging.LogRecord) -> None:
     """Public helper to call ``RedactingFormatter._redact_message`` for tests."""
     formatter._redact_message(record)
+
+
+__all__: list[str] = [
+    "RedactingFormatter",
+    "redact_structured_helper",
+    "redact_message_helper",
+]


### PR DESCRIPTION
## Summary
- expose `redact_structured_helper` and `redact_message_helper` via `__all__`
- use explicit type hints for these helper functions

## Testing
- `poetry run pre-commit run --files apiconfig/utils/logging/formatters/redacting.py`

------
https://chatgpt.com/codex/tasks/task_e_684918b892c0833295d84fbbfec3e82a