### PR TITLE
fix: typed callable for test_redacting monkeypatch

### DIFF
--- a/tests/unit/utils/logging/formatters/test_redacting.py
+++ b/tests/unit/utils/logging/formatters/test_redacting.py
@@ -507,11 +507,8 @@ def test_redacting_formatter_line_220_direct(monkeypatch: pytest.MonkeyPatch) ->
     redacted_dict = {"form_data": "[REDACTED]"}
 
     # Override redact_body to return our dict using monkeypatch
-    monkeypatch.setattr(
-        fmt,
-        "_redact_body",
-        lambda msg, **kwargs: redacted_dict if msg == string_input else msg,
-    )
+    redact_body_override: Callable[..., dict[str, str]] = lambda msg, **kwargs: redacted_dict if msg == string_input else msg
+    monkeypatch.setattr(fmt, "_redact_body", redact_body_override)
 
     try:
         # Call _redact_structured with our string input and form content type


### PR DESCRIPTION
## Summary
- add typed callable variable in test_redacting when overriding `_redact_body`

## Testing
- `poetry run pre-commit run --files tests/unit/utils/logging/formatters/test_redacting.py`


------
https://chatgpt.com/codex/tasks/task_e_684918b79608833283a5df07abcf0307