### PR TITLE
Fix MockClientConfigValid type overrides

### DIFF
--- a/tests/unit/testing/unit/test_assertions.py
+++ b/tests/unit/testing/unit/test_assertions.py
@@ -35,9 +35,9 @@ def test_type_checking_imports() -> None:
 class MockClientConfigValid(ClientConfig):
     """A valid mock ClientConfig."""
 
-    hostname: str = "api.example.com"
-    timeout: int = 10
-    retries: int = 2
+    hostname: str | None = "api.example.com"
+    timeout: int | None = 10
+    retries: int | None = 2
 
     @property
     def base_url(self) -> str:


### PR DESCRIPTION
## Summary
- align `MockClientConfigValid` attribute types with `ClientConfig`

## Testing
- `poetry run pre-commit run --files tests/unit/testing/unit/test_assertions.py`
- `poetry run pytest tests/unit/testing/unit/test_assertions.py`

------
https://chatgpt.com/codex/tasks/task_e_684918b5e4848332a69449d2a2937b96