### PR TITLE
Add helpers for DetailedFormatter private methods

### DIFF
--- a/apiconfig/utils/logging/formatters/__init__.py
+++ b/apiconfig/utils/logging/formatters/__init__.py
@@ -12,6 +12,8 @@ from apiconfig.utils.redaction.headers import (
 from .detailed import DetailedFormatter
 from .redacting import (
     RedactingFormatter,
+    format_exception_text_helper,
+    format_stack_info_helper,
     redact_message_helper,
     redact_structured_helper,
 )
@@ -26,4 +28,6 @@ __all__: list[str] = [
     "DEFAULT_SENSITIVE_HEADER_PREFIXES",
     "redact_message_helper",
     "redact_structured_helper",
+    "format_exception_text_helper",
+    "format_stack_info_helper",
 ]

--- a/apiconfig/utils/logging/formatters/redacting.py
+++ b/apiconfig/utils/logging/formatters/redacting.py
@@ -21,6 +21,8 @@ from apiconfig.utils.redaction.headers import (
     redact_headers,
 )
 
+from .detailed import DetailedFormatter
+
 
 class RedactingFormatter(logging.Formatter):
     """Automatically redact sensitive information from log messages and HTTP headers.
@@ -280,3 +282,21 @@ def redact_structured_helper(formatter: "RedactingFormatter", msg: Any, content_
 def redact_message_helper(formatter: "RedactingFormatter", record: logging.LogRecord) -> None:
     """Public helper to call ``RedactingFormatter._redact_message`` for tests."""
     formatter._redact_message(record)
+
+
+def format_exception_text_helper(
+    formatter: "DetailedFormatter",
+    formatted: str,
+    record: logging.LogRecord,
+) -> str:
+    """Public helper to call ``DetailedFormatter._format_exception_text`` for tests."""
+    return formatter._format_exception_text(formatted, record)
+
+
+def format_stack_info_helper(
+    formatter: "DetailedFormatter",
+    formatted: str,
+    record: logging.LogRecord,
+) -> str:
+    """Public helper to call ``DetailedFormatter._format_stack_info`` for tests."""
+    return formatter._format_stack_info(formatted, record)

--- a/tests/unit/utils/logging/formatters/test_detailed.py
+++ b/tests/unit/utils/logging/formatters/test_detailed.py
@@ -5,7 +5,10 @@ from typing import Any, Callable
 
 import pytest
 
-from apiconfig.utils.logging.formatters import DetailedFormatter
+from apiconfig.utils.logging.formatters import (
+    DetailedFormatter,
+    format_exception_text_helper,
+)
 
 
 class TypedLogRecord(logging.LogRecord):
@@ -231,7 +234,7 @@ def test_detailed_formatter_exc_info_sets_exc_text_branch(
 def test_detailed_formatter_format_exception_text_direct(
     log_record_factory: Callable[..., logging.LogRecord],
 ) -> None:
-    """Test that directly calls _format_exception_text to ensure line 72 is covered."""
+    """Test _format_exception_text via its public helper."""
     fmt = DetailedFormatter()
     try:
         raise ValueError("direct test")
@@ -243,9 +246,9 @@ def test_detailed_formatter_format_exception_text_direct(
         if hasattr(record, "exc_text"):
             delattr(record, "exc_text")
 
-        # Call _format_exception_text directly
+        # Call the helper that invokes _format_exception_text
         formatted = ""
-        formatted = fmt._format_exception_text(formatted, record)
+        formatted = format_exception_text_helper(fmt, formatted, record)
 
         # Verify exc_text was set by the method
         assert hasattr(record, "exc_text")


### PR DESCRIPTION
## Summary
- expose helpers for `_format_exception_text` and `_format_stack_info`
- export the helpers in `__all__`
- update tests to use new wrapper instead of private method

## Testing
- `pre-commit run --files apiconfig/utils/logging/formatters/redacting.py apiconfig/utils/logging/formatters/__init__.py tests/unit/utils/logging/formatters/test_detailed.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684918b45138833281b1f62d4f4e508b