### PR TITLE
Fix return type annotation

### DIFF
--- a/apiconfig/testing/integration/helpers.py
+++ b/apiconfig/testing/integration/helpers.py
@@ -5,7 +5,8 @@
 import typing
 import uuid
 
-from httpx import Client, Response
+import httpx
+from httpx import Client
 from pytest_httpserver import HTTPServer
 
 from apiconfig.auth.base import AuthStrategy
@@ -24,7 +25,7 @@ def make_request_with_config(
     path: str,
     method: str = "GET",
     **kwargs: typing.Any,
-) -> Response:
+) -> httpx.Response:
     """Make an HTTP request using the provided config and auth strategy to a mock server.
 
     Handles applying authentication via the strategy's `prepare_request` method.
@@ -46,7 +47,7 @@ def make_request_with_config(
 
     Returns
     -------
-    Response
+    httpx.Response
         The httpx Response object.
     """
     base_url = mock_server_url.rstrip("/")


### PR DESCRIPTION
## Summary
- use `httpx.Response` return type for `make_request_with_config`
- keep import of `Client` for tests

## Testing
- `poetry run pytest -q`
- `poetry run mypy apiconfig/ tests/`
- `poetry run flake8 apiconfig/ tests/`
- `poetry run black --check apiconfig/ tests/`
- `poetry run isort --check-only apiconfig/ tests/`
- `poetry run tox -q` *(fails: InterpreterNotFound: python3.13)*
- `poetry run pre-commit run --files apiconfig/testing/integration/helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68497aa23ca48332b2723dbe3ff45c1b