### PR TITLE
Fix typed result lists in component tests

### DIFF
--- a/tests/component/test_enhanced_auth_mocks_refresh.py
+++ b/tests/component/test_enhanced_auth_mocks_refresh.py
@@ -16,6 +16,7 @@ from apiconfig.testing.unit.mocks.auth import (
     MockHttpRequestCallable,
     MockRefreshableAuthStrategy,
 )
+from apiconfig.types import TokenRefreshResult
 
 
 class TestEnhancedAuthMocksRefresh:
@@ -200,13 +201,14 @@ class TestEnhancedAuthMocksRefresh:
         assert hasattr(strategy, "_max_concurrent_refreshes")
 
         # Test concurrent refresh operations
-        results = []
-        errors = []
+        results: list[TokenRefreshResult] = []
+        errors: list[Exception] = []
 
         def refresh_worker() -> None:
             try:
                 result = strategy.refresh()
-                results.append(result)
+                if result is not None:
+                    results.append(result)
             except Exception as e:
                 errors.append(e)
 

--- a/tests/component/test_phase2_cross_component_integration.py
+++ b/tests/component/test_phase2_cross_component_integration.py
@@ -293,7 +293,7 @@ class TestPhase2CrossComponentIntegration:
     def test_performance_cross_component(self) -> None:
         """Test performance of cross-component operations."""
         # Create multiple mock strategies
-        strategies = []
+        strategies: List[MockBearerAuthWithRefresh] = []
         for i in range(10):
             strategy = MockBearerAuthWithRefresh(initial_token=f"perf_token_{i}", refresh_delay=0.0)  # No artificial delay
             strategies.append(strategy)


### PR DESCRIPTION
## Summary
- fix type annotations in concurrent refresh test
- type strategies list for performance test

## Testing
- `poetry run pre-commit run --files tests/component/test_enhanced_auth_mocks_refresh.py tests/component/test_phase2_cross_component_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68497aa2f32883328e9cb736841f38a5