### PR TITLE
Fix log typing in server assertions

### DIFF
--- a/apiconfig/testing/integration/servers.py
+++ b/apiconfig/testing/integration/servers.py
@@ -168,7 +168,7 @@ def assert_request_received(
     matching_requests: List[Tuple[Request, Response]] = []
     lower_expected_headers: dict[str, str] | None = {k.lower(): v for k, v in expected_headers.items()} if expected_headers else None
 
-    log = httpserver.log
+    log: list[tuple[Request, Response]] = httpserver.log
     for entry in log:
         request: Request = entry[0]  # entry is a tuple (request, response)
         if request.path == path and request.method == method:


### PR DESCRIPTION
## Summary
- add typing when iterating over httpserver.log

## Testing
- `poetry run pytest`
- `poetry run pre-commit run --files apiconfig/testing/integration/servers.py`


------
https://chatgpt.com/codex/tasks/task_e_68497aa16ddc8332a7bfee8a9ab328f3