### PR TITLE
Fix TypedDict access in refresh test

### DIFF
--- a/tests/component/test_end_to_end_refresh.py
+++ b/tests/component/test_end_to_end_refresh.py
@@ -102,7 +102,7 @@ class TestEndToEndRefresh:
 
         result = auth.refresh()
         assert result is not None
-        token_data = result["token_data"]
+        token_data = result.get("token_data")
         assert token_data is not None
         assert token_data.get("access_token") == "new_token"
 


### PR DESCRIPTION
## Summary
- avoid direct access to optional `token_data` key in custom auth test

## Testing
- `poetry run pre-commit run --files tests/component/test_end_to_end_refresh.py`

------
https://chatgpt.com/codex/tasks/task_e_68497aa11eec8332bfcfa9cffe8f5782