### PR TITLE
Fix unused variable in token expiry tests

### DIFF
--- a/tests/unit/testing/mocks/test_token_expiry_reliability.py
+++ b/tests/unit/testing/mocks/test_token_expiry_reliability.py
@@ -193,7 +193,7 @@ class TestRaceConditionPrevention:
             start_time = time.time()
 
             # Measure every 10ms for 100ms
-            for i in range(10):
+            for _ in range(10):
                 is_expired = strategy.is_expired()
                 elapsed = time.time() - start_time
                 measurements.append((elapsed, is_expired))


### PR DESCRIPTION
## Summary
- remove unused variable warning in token expiry reliability test

## Testing
- `poetry run pre-commit run --files tests/unit/testing/mocks/test_token_expiry_reliability.py`


------
https://chatgpt.com/codex/tasks/task_e_68497a9ffc808332aecbe8a210bddb1d