### PR TITLE
Fix type hint for measurements list

### DIFF
--- a/tests/unit/testing/mocks/test_token_expiry_reliability.py
+++ b/tests/unit/testing/mocks/test_token_expiry_reliability.py
@@ -189,7 +189,7 @@ class TestRaceConditionPrevention:
             )
 
             # Take measurements at specific intervals
-            measurements = []
+            measurements: list[tuple[float, bool]] = []
             start_time = time.time()
 
             # Measure every 10ms for 100ms


### PR DESCRIPTION
## Summary
- type `measurements` to avoid partially unknown types in tests

## Testing
- `poetry run pytest tests/unit/`
- `poetry run mypy apiconfig/ tests/`
- `poetry run pre-commit run --files tests/unit/testing/mocks/test_token_expiry_reliability.py`


------
https://chatgpt.com/codex/tasks/task_e_68497a9f6230833286b71be779fdee45