### PR TITLE
Fix pytest_httpserver Request protocol

### DIFF
--- a/typings/pytest_httpserver/__init__.pyi
+++ b/typings/pytest_httpserver/__init__.pyi
@@ -1,6 +1,16 @@
-from typing import Any, List, Mapping, Pattern, Tuple
+from typing import Any, Iterable, List, Mapping, Pattern, Tuple, Protocol
 
-from werkzeug.wrappers import Request, Response
+from werkzeug.wrappers import Response
+
+class _HeaderMapping(Protocol):
+    def items(self) -> Iterable[tuple[str, str]]: ...
+
+class _ArgsMapping(Protocol):
+    def items(self) -> Iterable[tuple[str, str]]: ...
+
+class Request(Protocol):
+    headers: _HeaderMapping
+    args: _ArgsMapping
 
 class RequestHandler:
     def respond_with_json(self, obj: Any, *, status: int = ..., headers: Mapping[str, str] | None = ...) -> None: ...


### PR DESCRIPTION
## Summary
- update stub for pytest_httpserver
- run pre-commit and tests

## Testing
- `poetry run pre-commit run --files typings/pytest_httpserver/__init__.pyi`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68497a9eea40833295589820061fa369