### PR TITLE
Fix expected headers construction

### DIFF
--- a/apiconfig/testing/integration/servers.py
+++ b/apiconfig/testing/integration/servers.py
@@ -166,7 +166,13 @@ def assert_request_received(
         If the expected request(s) were not found in the server log.
     """
     matching_requests: List[Tuple[Request, Response]] = []
-    lower_expected_headers: dict[str, str] | None = {k.lower(): v for k, v in expected_headers.items()} if expected_headers else None
+    lower_expected_headers: dict[str, str] | None = None
+    if expected_headers:
+        lower_expected_headers = {}
+        for key, value in expected_headers.items():
+            key_str: str = key
+            value_str: str = value
+            lower_expected_headers[key_str.lower()] = value_str
 
     log: list[tuple[Request, Response]] = httpserver.log
     for entry in log:


### PR DESCRIPTION
## Summary
- remove inline dict comprehension in integration test server helper
- build header dict step by step to avoid pyright unknown variable warnings

## Testing
- `poetry run pytest`
- `poetry run pre-commit run --files apiconfig/testing/integration/servers.py`

------
https://chatgpt.com/codex/tasks/task_e_68498b0eefe48332994ca4c39cc1919b