### PR TITLE
Add typing for thread lists in tests

### DIFF
--- a/tests/component/test_enhanced_auth_mocks_refresh.py
+++ b/tests/component/test_enhanced_auth_mocks_refresh.py
@@ -213,7 +213,7 @@ class TestEnhancedAuthMocksRefresh:
                 errors.append(e)
 
         # Start multiple threads
-        threads = []
+        threads: list[threading.Thread] = []
         for _ in range(3):
             thread = threading.Thread(target=refresh_worker)
             threads.append(thread)

--- a/tests/component/test_phase2_cross_component_integration.py
+++ b/tests/component/test_phase2_cross_component_integration.py
@@ -173,7 +173,7 @@ class TestPhase2CrossComponentIntegration:
                 verification_errors.append(e)
 
         # Start multiple verification threads
-        threads = []
+        threads: list[threading.Thread] = []
         for _ in range(3):
             thread = threading.Thread(target=verify_worker)
             threads.append(thread)

--- a/tests/component/test_phase2_error_scenarios.py
+++ b/tests/component/test_phase2_error_scenarios.py
@@ -19,6 +19,7 @@ from apiconfig.testing.unit.mocks.auth import (
     MockHttpRequestCallable,
     MockRefreshableAuthStrategy,
 )
+from apiconfig.types import TokenRefreshResult
 
 
 class TestPhase2ErrorScenarios:
@@ -334,8 +335,8 @@ class TestPhase2ErrorScenarios:
         # Create a strategy that fails after first attempt
         concurrent_fail_strategy = MockAuthErrorInjector.create_failing_refresh_strategy(failure_type="auth", failure_after_attempts=1)
 
-        errors = []
-        successes = []
+        errors: list[Exception] = []
+        successes: list[TokenRefreshResult | None] = []
 
         def concurrent_refresh() -> None:
             try:
@@ -345,7 +346,7 @@ class TestPhase2ErrorScenarios:
                 errors.append(e)
 
         # Start multiple threads
-        threads = []
+        threads: list[threading.Thread] = []
         for _ in range(3):
             thread = threading.Thread(target=concurrent_refresh)
             threads.append(thread)

--- a/tests/unit/testing/mocks/test_token_expiry_reliability.py
+++ b/tests/unit/testing/mocks/test_token_expiry_reliability.py
@@ -8,7 +8,10 @@ from typing import List, Tuple
 
 import pytest
 
-from apiconfig.testing.unit.mocks.auth import AuthTestScenarioBuilder
+from apiconfig.testing.unit.mocks.auth import (
+    AuthTestScenarioBuilder,
+    MockBearerAuthWithRefresh,
+)
 
 
 class TestTokenExpiryReliability:
@@ -32,7 +35,7 @@ class TestTokenExpiryReliability:
                 sum(range(1000))
 
         # Start multiple CPU-burning threads to simulate high load
-        burn_threads = []
+        burn_threads: list[threading.Thread] = []
         for _ in range(10):  # 10 threads to really stress the system
             thread = threading.Thread(target=cpu_burner, daemon=True)
             thread.start()
@@ -166,7 +169,7 @@ class TestRaceConditionPrevention:
         initial_thread_count = threading.active_count()
 
         # Create multiple expiry scenarios
-        strategies = []
+        strategies: list[MockBearerAuthWithRefresh] = []
         for i in range(10):
             strategy = AuthTestScenarioBuilder.create_token_expiry_scenario(initial_token=f"thread_test_{i}", expires_after_seconds=0.1 * (i + 1))
             strategies.append(strategy)


### PR DESCRIPTION
## Summary
- specify `list[threading.Thread]` for several thread lists
- type successes/errors lists in error scenario tests
- improve imports for typed mocks

## Testing
- `poetry run pre-commit run --files tests/component/test_enhanced_auth_mocks_refresh.py tests/component/test_phase2_cross_component_integration.py tests/component/test_phase2_error_scenarios.py tests/unit/testing/mocks/test_token_expiry_reliability.py`
- `poetry run pytest tests/component/test_enhanced_auth_mocks_refresh.py tests/component/test_phase2_cross_component_integration.py tests/component/test_phase2_error_scenarios.py tests/unit/testing/mocks/test_token_expiry_reliability.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68498b0ffb40833285ad4c9a93a94a90