### PR TITLE
Fix pyright warning in redacting formatter tests

### DIFF
--- a/tests/unit/utils/logging/formatters/test_redacting.py
+++ b/tests/unit/utils/logging/formatters/test_redacting.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 import pytest
 
@@ -507,7 +507,9 @@ def test_redacting_formatter_line_220_direct(monkeypatch: pytest.MonkeyPatch) ->
     redacted_dict = {"form_data": "[REDACTED]"}
 
     # Override redact_body to return our dict using monkeypatch
-    redact_body_override: Callable[..., dict[str, str]] = lambda msg, **kwargs: redacted_dict if msg == string_input else msg
+    def redact_body_override(msg: str, **kwargs: Any) -> dict[str, str]:
+        return redacted_dict if msg == string_input else cast(dict[str, str], msg)
+
     monkeypatch.setattr(fmt, "_redact_body", redact_body_override)
 
     try:


### PR DESCRIPTION
## Summary
- replace lambda in `test_redacting.py` with a named function
- run pyright to confirm warnings are resolved

## Testing
- `poetry run pre-commit run --files tests/unit/utils/logging/formatters/test_redacting.py`
- `poetry run pyright tests/unit/utils/logging/formatters/test_redacting.py`

------
https://chatgpt.com/codex/tasks/task_e_68498b1299848332899e9019fe3ecd3c