### PR TITLE
Fix TokenRefreshResult test accesses

### DIFF
--- a/tests/component/test_end_to_end_refresh.py
+++ b/tests/component/test_end_to_end_refresh.py
@@ -71,7 +71,7 @@ class TestEndToEndRefresh:
         assert "token_data" in result
         assert "config_updates" in result
 
-        token_data = result["token_data"]
+        token_data = result.get("token_data")
         assert token_data is not None
         assert token_data.get("access_token") == "new_access_token"
         assert token_data.get("refresh_token") == "new_refresh_token"

--- a/tests/component/test_enhanced_auth_mocks_refresh.py
+++ b/tests/component/test_enhanced_auth_mocks_refresh.py
@@ -36,10 +36,10 @@ class TestEnhancedAuthMocksRefresh:
         result = mock_auth.refresh()
         assert result is not None
         assert "token_data" in result
-        token_data = result["token_data"]
+        token_data = result.get("token_data")
         assert token_data is not None
         assert "access_token" in token_data
-        assert token_data["access_token"] == "initial_token_refreshed_1"
+        assert token_data.get("access_token") == "initial_token_refreshed_1"
         assert mock_auth.current_token == "initial_token_refreshed_1"
 
     def test_mock_refreshable_auth_strategy_refresh_failure(self) -> None:

--- a/tests/component/test_existing_component_integration.py
+++ b/tests/component/test_existing_component_integration.py
@@ -54,7 +54,7 @@ class TestExistingComponentIntegration:
 
         # Simulate saving updated token data back to storage
         assert result is not None
-        token_data = result["token_data"]
+        token_data = result.get("token_data")
         assert token_data is not None
         updated_token_data = {
             "access_token": token_data.get("access_token"),
@@ -135,7 +135,7 @@ class TestExistingComponentIntegration:
         # Test refresh and storage update
         result = auth.refresh()
         assert result is not None
-        token_data = result["token_data"]
+        token_data = result.get("token_data")
         assert token_data is not None
         assert token_data.get("access_token") == "refreshed_api_key"
 

--- a/tests/component/test_phase2_cross_component_integration.py
+++ b/tests/component/test_phase2_cross_component_integration.py
@@ -46,7 +46,7 @@ class TestPhase2CrossComponentIntegration:
             # Verify refresh result structure
             assert result is not None
             assert "token_data" in result
-            token_data = result["token_data"]
+            token_data = result.get("token_data")
             assert token_data is not None
             assert "access_token" in token_data
 

--- a/tests/component/test_refresh_performance.py
+++ b/tests/component/test_refresh_performance.py
@@ -77,7 +77,7 @@ class TestRefreshPerformance:
         # Should be fast
         assert refresh_time < 0.01
         assert result is not None
-        token_data = result["token_data"]
+        token_data = result.get("token_data")
         assert token_data is not None
         assert token_data.get("access_token") == "new_token_1"
 

--- a/tests/integration/test_tripletex_auth_refresh.py
+++ b/tests/integration/test_tripletex_auth_refresh.py
@@ -101,12 +101,12 @@ class TestTripletexAuthRefresh:
             assert "token_data" in result
             assert "config_updates" in result
 
-            token_data = result["token_data"]
+            token_data = result.get("token_data")
             assert token_data is not None
             assert "access_token" in token_data
             assert "expires_in" in token_data
             assert "token_type" in token_data
-            assert token_data["token_type"] == "session"
+            assert token_data.get("token_type") == "session"
 
     def test_concurrent_refresh_thread_safety(self, tripletex_client: TripletexClient) -> None:
         """Test that concurrent refresh operations are thread-safe."""

--- a/tests/unit/auth/strategies/test_custom.py
+++ b/tests/unit/auth/strategies/test_custom.py
@@ -335,10 +335,11 @@ class TestCustomAuthFactoryMethods:
         # Test refresh functionality
         result = auth.refresh()
         assert result is not None
-        assert result["token_data"] is not None
-        assert result["token_data"]["access_token"] == "refreshed-token-1"
-        assert result["token_data"]["token_type"] == "session"
-        assert result["config_updates"] is None
+        token_data = result.get("token_data")
+        assert token_data is not None
+        assert token_data.get("access_token") == "refreshed-token-1"
+        assert token_data.get("token_type") == "session"
+        assert result.get("config_updates") is None
 
         # Test that headers are updated after refresh
         headers = auth.prepare_request_headers()
@@ -445,8 +446,9 @@ class TestCustomAuthRefreshIntegration:
         # Refresh the token
         result = auth.refresh()
         assert result is not None
-        assert result["token_data"] is not None
-        assert result["token_data"]["access_token"] == "refreshed-token"
+        token_data = result.get("token_data")
+        assert token_data is not None
+        assert token_data.get("access_token") == "refreshed-token"
 
         # Token should no longer be expired and headers should be updated
         assert not auth.is_expired()

--- a/tests/unit/auth/test_auth_base.py
+++ b/tests/unit/auth/test_auth_base.py
@@ -151,8 +151,10 @@ class TestAuthStrategy:
 
         assert result is not None
         assert "token_data" in result
-        assert result["token_data"]["access_token"] == "new-token"  # type: ignore
-        assert result["token_data"]["expires_in"] == 3600  # type: ignore
+        token_data = result.get("token_data")
+        assert token_data is not None
+        assert token_data.get("access_token") == "new-token"
+        assert token_data.get("expires_in") == 3600
 
     def test_refreshable_strategy_refresh_raises_when_cannot_refresh(self) -> None:
         """Test that RefreshableAuthStrategy.refresh raises NotImplementedError when cannot refresh."""

--- a/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
+++ b/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
@@ -97,13 +97,13 @@ class TestMockRefreshableAuthStrategy:
         result = strategy.refresh()
 
         assert result is not None
-        assert result["token_data"] is not None
-        token_data = result["token_data"]
+        token_data = result.get("token_data")
+        assert token_data is not None
         assert token_data.get("access_token") == "initial_refreshed_1"
         assert token_data.get("refresh_token") == "refresh_token_new"
         assert token_data.get("expires_in") == 3600
         assert token_data.get("token_type") == "Bearer"
-        assert result["config_updates"] is None
+        assert result.get("config_updates") is None
         assert strategy.current_token == "initial_refreshed_1"
         assert strategy._refresh_attempts == 1
         assert strategy.is_expired() is False
@@ -141,11 +141,13 @@ class TestMockRefreshableAuthStrategy:
 
         assert strategy._refresh_attempts == 2
         assert result1 is not None
-        assert result1["token_data"] is not None
-        assert result1["token_data"]["access_token"] == "mock_token_refreshed_1"
+        token_data1 = result1.get("token_data")
+        assert token_data1 is not None
+        assert token_data1.get("access_token") == "mock_token_refreshed_1"
         assert result2 is not None
-        assert result2["token_data"] is not None
-        assert result2["token_data"]["access_token"] == "mock_token_refreshed_2"
+        token_data2 = result2.get("token_data")
+        assert token_data2 is not None
+        assert token_data2.get("access_token") == "mock_token_refreshed_2"
 
     def test_get_refresh_callback_when_can_refresh(self) -> None:
         """Test get_refresh_callback returns callback when refresh is possible."""


### PR DESCRIPTION
## Summary
- guard `token_data` access in tests
- drop unnecessary type ignores

## Testing
- `pre-commit run --files tests/component/test_end_to_end_refresh.py tests/component/test_enhanced_auth_mocks_refresh.py tests/component/test_existing_component_integration.py tests/component/test_phase2_cross_component_integration.py tests/component/test_refresh_performance.py tests/integration/test_tripletex_auth_refresh.py tests/unit/auth/strategies/test_custom.py tests/unit/auth/test_auth_base.py tests/unit/testing/mocks/test_enhanced_auth_mocks.py`

------
https://chatgpt.com/codex/tasks/task_e_68498b111b7083329be8c0e6bbc09b16