### PR TITLE
Fix refresh override typing in auth mock tests

### DIFF
--- a/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
+++ b/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
@@ -3,7 +3,7 @@
 
 import threading
 import time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +18,7 @@ from apiconfig.testing.unit.mocks.auth import (
     MockHttpRequestCallable,
     MockRefreshableAuthStrategy,
 )
+from apiconfig.types import TokenRefreshResult
 
 
 class TestMockRefreshableAuthStrategy:
@@ -178,10 +179,12 @@ class TestMockRefreshableAuthStrategy:
 
     def test_refresh_callback_raises_on_none_result(self) -> None:
         """Test refresh callback raises error when refresh returns None."""
-        strategy = MockRefreshableAuthStrategy()
 
-        # Mock refresh to return None
-        strategy.refresh = lambda: None  # type: ignore[method-assign]
+        class RefreshReturnsNone(MockRefreshableAuthStrategy):
+            def refresh(self) -> Optional[TokenRefreshResult]:
+                return None
+
+        strategy = RefreshReturnsNone()
 
         callback = strategy.get_refresh_callback()
 


### PR DESCRIPTION
## Summary
- create subclass to override `refresh` in test
- clean up imports

## Testing
- `pre-commit run --files tests/unit/testing/mocks/test_enhanced_auth_mocks.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68498b161bfc8332bbd639076b0ddc4e