### PR TITLE
test: silence pyright private access

### DIFF
--- a/apiconfig/testing/unit/mocks/auth.py
+++ b/apiconfig/testing/unit/mocks/auth.py
@@ -548,7 +548,7 @@ class AuthTestScenarioBuilder:
 
         # Set expiry time based on current time + expiry duration
         # This avoids race conditions with background threads
-        strategy._expiry_time = time.time() + expires_after_seconds
+        strategy._expiry_time = time.time() + expires_after_seconds  # pyright: ignore[reportPrivateUsage]
         return strategy
 
     @staticmethod
@@ -568,20 +568,20 @@ class AuthTestScenarioBuilder:
         strategy = MockBearerAuthWithRefresh(max_refresh_attempts=num_concurrent_refreshes + 5)
 
         # Add thread safety tracking
-        strategy._refresh_lock = threading.Lock()
-        strategy._concurrent_refreshes = 0
-        strategy._max_concurrent_refreshes = 0
+        strategy._refresh_lock = threading.Lock()  # pyright: ignore[reportPrivateUsage]
+        strategy._concurrent_refreshes = 0  # pyright: ignore[reportPrivateUsage]
+        strategy._max_concurrent_refreshes = 0  # pyright: ignore[reportPrivateUsage]
 
         original_refresh = strategy.refresh
 
         def thread_safe_refresh() -> Optional[TokenRefreshResult]:
-            lock = strategy._refresh_lock
+            lock = strategy._refresh_lock  # pyright: ignore[reportPrivateUsage]
             assert lock is not None
             with lock:
-                strategy._concurrent_refreshes += 1
+                strategy._concurrent_refreshes += 1  # pyright: ignore[reportPrivateUsage]
                 strategy._max_concurrent_refreshes = max(
-                    strategy._max_concurrent_refreshes,
-                    strategy._concurrent_refreshes,
+                    strategy._max_concurrent_refreshes,  # pyright: ignore[reportPrivateUsage]
+                    strategy._concurrent_refreshes,  # pyright: ignore[reportPrivateUsage]
                 )
 
             try:
@@ -590,7 +590,7 @@ class AuthTestScenarioBuilder:
             finally:
                 assert lock is not None
                 with lock:
-                    strategy._concurrent_refreshes -= 1
+                    strategy._concurrent_refreshes -= 1  # pyright: ignore[reportPrivateUsage]
 
         setattr(strategy, "refresh", thread_safe_refresh)
         return strategy
@@ -607,8 +607,8 @@ class AuthTestScenarioBuilder:
         strategy = MockRefreshableAuthStrategy()
 
         # Track callback usage
-        strategy._callback_calls = 0
-        strategy._callback_errors = []
+        strategy._callback_calls = 0  # pyright: ignore[reportPrivateUsage]
+        strategy._callback_errors = []  # pyright: ignore[reportPrivateUsage]
 
         original_get_refresh_callback = strategy.get_refresh_callback
 
@@ -618,11 +618,11 @@ class AuthTestScenarioBuilder:
                 return None
 
             def tracked_callback() -> None:
-                strategy._callback_calls += 1
+                strategy._callback_calls += 1  # pyright: ignore[reportPrivateUsage]
                 try:
                     return callback()
                 except Exception as e:
-                    strategy._callback_errors.append(e)
+                    strategy._callback_errors.append(e)  # pyright: ignore[reportPrivateUsage]
                     raise
 
             return tracked_callback

--- a/tests/component/test_enhanced_auth_mocks_refresh.py
+++ b/tests/component/test_enhanced_auth_mocks_refresh.py
@@ -226,7 +226,7 @@ class TestEnhancedAuthMocksRefresh:
         # Check results
         assert len(results) == 3
         assert len(errors) == 0
-        assert strategy._max_concurrent_refreshes >= 1
+        assert strategy._max_concurrent_refreshes >= 1  # pyright: ignore[reportPrivateUsage]
 
     def test_auth_test_scenario_builder_crudclient_integration(self) -> None:
         """Test AuthTestScenarioBuilder crudclient integration scenario."""
@@ -245,8 +245,8 @@ class TestEnhancedAuthMocksRefresh:
         callback()
 
         # Check tracking
-        assert strategy._callback_calls == 2
-        assert len(strategy._callback_errors) == 0
+        assert strategy._callback_calls == 2  # pyright: ignore[reportPrivateUsage]
+        assert len(strategy._callback_errors) == 0  # pyright: ignore[reportPrivateUsage]
 
     def test_mock_http_request_callable(self) -> None:
         """Test MockHttpRequestCallable functionality."""

--- a/tests/component/test_phase2_cross_component_integration.py
+++ b/tests/component/test_phase2_cross_component_integration.py
@@ -201,7 +201,7 @@ class TestPhase2CrossComponentIntegration:
         callback()
 
         # Verify callback was tracked
-        assert crudclient_strategy._callback_calls == 1
+        assert crudclient_strategy._callback_calls == 1  # pyright: ignore[reportPrivateUsage]
 
         # Verify new token
         headers: Dict[str, str] = {}

--- a/tests/integration/test_tripletex_auth_refresh.py
+++ b/tests/integration/test_tripletex_auth_refresh.py
@@ -47,10 +47,10 @@ class TestTripletexAuthRefresh:
         # First, ensure we have a valid token
         countries = tripletex_client.list_countries()
         assert isinstance(countries, dict)
-        old_token = auth_strategy._session_token
+        old_token = auth_strategy._session_token  # pyright: ignore[reportPrivateUsage]
 
         # Force token expiration
-        auth_strategy._token_expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        auth_strategy._token_expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)  # pyright: ignore[reportPrivateUsage]
         assert auth_strategy.is_expired()
 
         # Make request - should trigger refresh via prepare_request_headers
@@ -59,9 +59,11 @@ class TestTripletexAuthRefresh:
 
         # Verify new token was obtained and is not expired
         assert not auth_strategy.is_expired()
-        assert auth_strategy._session_token is not None
+        assert auth_strategy._session_token is not None  # pyright: ignore[reportPrivateUsage]
         # Token should be refreshed (new token)
-        assert auth_strategy._session_token != old_token or auth_strategy._token_expires_at > datetime.now(timezone.utc)
+        assert auth_strategy._session_token != old_token or auth_strategy._token_expires_at > datetime.now(
+            timezone.utc
+        )  # pyright: ignore[reportPrivateUsage]
 
     def test_refresh_callback_integration(self, tripletex_client: TripletexClient) -> None:
         """Test integration with crudclient-style refresh callback."""
@@ -77,18 +79,18 @@ class TestTripletexAuthRefresh:
         assert refresh_callback is not None
 
         # Store old token and expiry
-        old_token = auth_strategy._session_token
-        old_expiry = auth_strategy._token_expires_at
+        old_token = auth_strategy._session_token  # pyright: ignore[reportPrivateUsage]
+        old_expiry = auth_strategy._token_expires_at  # pyright: ignore[reportPrivateUsage]
 
         # Simulate crudclient retry logic calling the callback
         refresh_callback()  # Should refresh without error
 
         # Verify token was refreshed
-        new_token = auth_strategy._session_token
+        new_token = auth_strategy._session_token  # pyright: ignore[reportPrivateUsage]
         assert new_token is not None
         assert not auth_strategy.is_expired()
         # Either token changed or expiry was updated
-        assert new_token != old_token or auth_strategy._token_expires_at != old_expiry
+        assert new_token != old_token or auth_strategy._token_expires_at != old_expiry  # pyright: ignore[reportPrivateUsage]
 
     def test_token_refresh_result_structure(self, tripletex_client: TripletexClient) -> None:
         """Test that refresh returns proper TokenRefreshResult structure."""
@@ -143,8 +145,8 @@ class TestTripletexAuthRefresh:
         assert len(results) > 0, "No successful refresh operations"
 
         # Verify final state is consistent (token should be valid)
-        assert auth_strategy._session_token is not None
-        assert auth_strategy._token_expires_at is not None
+        assert auth_strategy._session_token is not None  # pyright: ignore[reportPrivateUsage]
+        assert auth_strategy._token_expires_at is not None  # pyright: ignore[reportPrivateUsage]
 
     def test_refresh_failure_handling(self, tripletex_client: TripletexClient) -> None:
         """Test proper error handling when refresh fails."""
@@ -195,7 +197,7 @@ class TestTripletexLiveScenarios:
         # 2. Force token expiration
         auth_strategy = tripletex_client.config.auth_strategy
         assert isinstance(auth_strategy, TripletexSessionAuth)
-        auth_strategy._token_expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        auth_strategy._token_expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)  # pyright: ignore[reportPrivateUsage]
 
         # 3. Make another API call - should trigger refresh
         companies = tripletex_client.list_currencies()
@@ -222,7 +224,7 @@ class TestTripletexLiveScenarios:
         assert setup_auth_func is not None
 
         # Simulate 401 error scenario
-        auth_strategy._token_expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        auth_strategy._token_expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)  # pyright: ignore[reportPrivateUsage]
 
         # Call setup_auth_func (as crudclient retry logic would)
         setup_auth_func()

--- a/tests/unit/auth/strategies/test_bearer.py
+++ b/tests/unit/auth/strategies/test_bearer.py
@@ -16,8 +16,8 @@ class TestBearerAuth:
         """Test initialization with a valid token only."""
         auth = BearerAuth(access_token="valid_token")
         assert auth.access_token == "valid_token"
-        assert auth._expires_at is None
-        assert auth._http_request_callable is None
+        assert auth._expires_at is None  # pyright: ignore[reportPrivateUsage]
+        assert auth._http_request_callable is None  # pyright: ignore[reportPrivateUsage]
 
     def test_init_with_all_parameters(self) -> None:
         """Test initialization with all parameters."""
@@ -27,8 +27,8 @@ class TestBearerAuth:
         auth = BearerAuth(access_token="valid_token", expires_at=expires_at, http_request_callable=http_callable)
 
         assert auth.access_token == "valid_token"
-        assert auth._expires_at == expires_at
-        assert auth._http_request_callable == http_callable
+        assert auth._expires_at == expires_at  # pyright: ignore[reportPrivateUsage]
+        assert auth._http_request_callable == http_callable  # pyright: ignore[reportPrivateUsage]
 
     def test_init_rejects_empty_token(self) -> None:
         """Test that BearerAuth rejects empty tokens."""

--- a/tests/unit/auth/strategies/test_custom.py
+++ b/tests/unit/auth/strategies/test_custom.py
@@ -46,7 +46,7 @@ class TestCustomAuth:
         assert auth.refresh_func is refresh_func
         assert auth.can_refresh_func is can_refresh_func
         assert auth.is_expired_func is is_expired_func
-        assert auth._http_request_callable is http_request_callable
+        assert auth._http_request_callable is http_request_callable  # pyright: ignore[reportPrivateUsage]
 
     def test_can_refresh_with_can_refresh_func(self) -> None:
         """Test can_refresh when can_refresh_func is provided."""
@@ -310,7 +310,7 @@ class TestCustomAuthFactoryMethods:
         http_callable = Mock()
         auth = CustomAuth.create_api_key_custom(api_key="test-key", http_request_callable=http_callable)
 
-        assert auth._http_request_callable is http_callable
+        assert auth._http_request_callable is http_callable  # pyright: ignore[reportPrivateUsage]
 
     def test_create_session_token_custom(self) -> None:
         """Test create_session_token_custom factory method."""
@@ -377,7 +377,7 @@ class TestCustomAuthFactoryMethods:
             session_token="initial-token", session_refresh_func=mock_refresh_func, http_request_callable=http_callable
         )
 
-        assert auth._http_request_callable is http_callable
+        assert auth._http_request_callable is http_callable  # pyright: ignore[reportPrivateUsage]
 
     def test_factory_methods_return_correct_type(self) -> None:
         """Test that factory methods return CustomAuth instances."""

--- a/tests/unit/auth/test_auth_base.py
+++ b/tests/unit/auth/test_auth_base.py
@@ -61,13 +61,13 @@ class TestAuthStrategy:
     def test_init_without_http_request_callable(self) -> None:
         """Test initialization without http_request_callable."""
         strategy = ConcreteAuthStrategy()
-        assert strategy._http_request_callable is None
+        assert strategy._http_request_callable is None  # pyright: ignore[reportPrivateUsage]
 
     def test_init_with_http_request_callable(self) -> None:
         """Test initialization with http_request_callable."""
         mock_callable = Mock()
         strategy = ConcreteAuthStrategy(http_request_callable=mock_callable)
-        assert strategy._http_request_callable is mock_callable
+        assert strategy._http_request_callable is mock_callable  # pyright: ignore[reportPrivateUsage]
 
     def test_can_refresh_default_implementation(self) -> None:
         """Test that can_refresh returns False by default."""

--- a/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
+++ b/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
@@ -30,12 +30,12 @@ class TestMockRefreshableAuthStrategy:
         assert strategy.initial_token == "mock_token"
         assert strategy.current_token == "mock_token"
         assert strategy.refresh_token == "mock_refresh"
-        assert strategy._can_refresh is True
-        assert strategy._refresh_success is True
-        assert strategy._refresh_delay == 0.0
-        assert strategy._max_refresh_attempts == 3
-        assert strategy._refresh_attempts == 0
-        assert strategy._is_expired is False
+        assert strategy._can_refresh is True  # pyright: ignore[reportPrivateUsage]
+        assert strategy._refresh_success is True  # pyright: ignore[reportPrivateUsage]
+        assert strategy._refresh_delay == 0.0  # pyright: ignore[reportPrivateUsage]
+        assert strategy._max_refresh_attempts == 3  # pyright: ignore[reportPrivateUsage]
+        assert strategy._refresh_attempts == 0  # pyright: ignore[reportPrivateUsage]
+        assert strategy._is_expired is False  # pyright: ignore[reportPrivateUsage]
 
     def test_init_custom_values(self) -> None:
         """Test initialization with custom values."""
@@ -51,10 +51,10 @@ class TestMockRefreshableAuthStrategy:
         assert strategy.initial_token == "custom_token"
         assert strategy.current_token == "custom_token"
         assert strategy.refresh_token == "custom_refresh"
-        assert strategy._can_refresh is False
-        assert strategy._refresh_success is False
-        assert strategy._refresh_delay == 1.0
-        assert strategy._max_refresh_attempts == 5
+        assert strategy._can_refresh is False  # pyright: ignore[reportPrivateUsage]
+        assert strategy._refresh_success is False  # pyright: ignore[reportPrivateUsage]
+        assert strategy._refresh_delay == 1.0  # pyright: ignore[reportPrivateUsage]
+        assert strategy._max_refresh_attempts == 5  # pyright: ignore[reportPrivateUsage]
 
     def test_can_refresh_true_when_enabled_and_under_limit(self) -> None:
         """Test can_refresh returns True when enabled and under attempt limit."""
@@ -69,7 +69,7 @@ class TestMockRefreshableAuthStrategy:
     def test_can_refresh_false_when_over_limit(self) -> None:
         """Test can_refresh returns False when over attempt limit."""
         strategy = MockRefreshableAuthStrategy(max_refresh_attempts=1)
-        strategy._refresh_attempts = 1
+        strategy._refresh_attempts = 1  # pyright: ignore[reportPrivateUsage]
         assert strategy.can_refresh() is False
 
     def test_is_expired_default_false(self) -> None:
@@ -105,7 +105,7 @@ class TestMockRefreshableAuthStrategy:
         assert token_data.get("token_type") == "Bearer"
         assert result["config_updates"] is None
         assert strategy.current_token == "initial_refreshed_1"
-        assert strategy._refresh_attempts == 1
+        assert strategy._refresh_attempts == 1  # pyright: ignore[reportPrivateUsage]
         assert strategy.is_expired() is False
 
     def test_refresh_with_delay(self) -> None:
@@ -139,7 +139,7 @@ class TestMockRefreshableAuthStrategy:
         result1 = strategy.refresh()
         result2 = strategy.refresh()
 
-        assert strategy._refresh_attempts == 2
+        assert strategy._refresh_attempts == 2  # pyright: ignore[reportPrivateUsage]
         assert result1 is not None
         assert result1["token_data"] is not None
         assert result1["token_data"]["access_token"] == "mock_token_refreshed_1"
@@ -174,7 +174,7 @@ class TestMockRefreshableAuthStrategy:
         callback()
 
         assert strategy.current_token != initial_token
-        assert strategy._refresh_attempts == 1
+        assert strategy._refresh_attempts == 1  # pyright: ignore[reportPrivateUsage]
 
     def test_refresh_callback_raises_on_none_result(self) -> None:
         """Test refresh callback raises error when refresh returns None."""
@@ -380,11 +380,11 @@ class TestAuthTestScenarioBuilder:
         strategy = AuthTestScenarioBuilder.create_concurrent_refresh_scenario()
 
         # Check that thread safety attributes are added
-        assert hasattr(strategy, "_refresh_lock")
-        assert hasattr(strategy, "_concurrent_refreshes")
-        assert hasattr(strategy, "_max_concurrent_refreshes")
-        assert getattr(strategy, "_concurrent_refreshes", None) == 0
-        assert getattr(strategy, "_max_concurrent_refreshes", None) == 0
+        assert hasattr(strategy, "_refresh_lock")  # pyright: ignore[reportPrivateUsage]
+        assert hasattr(strategy, "_concurrent_refreshes")  # pyright: ignore[reportPrivateUsage]
+        assert hasattr(strategy, "_max_concurrent_refreshes")  # pyright: ignore[reportPrivateUsage]
+        assert getattr(strategy, "_concurrent_refreshes", None) == 0  # pyright: ignore[reportPrivateUsage]
+        assert getattr(strategy, "_max_concurrent_refreshes", None) == 0  # pyright: ignore[reportPrivateUsage]
 
     def test_concurrent_refresh_tracking(self) -> None:
         """Test concurrent refresh tracking functionality."""
@@ -436,7 +436,7 @@ class TestAuthTestScenarioBuilder:
         strategy = AuthTestScenarioBuilder.create_crudclient_integration_scenario()
 
         # Make refresh fail
-        strategy._refresh_success = False
+        strategy._refresh_success = False  # pyright: ignore[reportPrivateUsage]
 
         callback = strategy.get_refresh_callback()
         assert callback is not None
@@ -771,7 +771,7 @@ class TestCrudclientIntegrationErrorHandling:
         strategy = AuthTestScenarioBuilder.create_crudclient_integration_scenario()
 
         # Make the original get_refresh_callback return None
-        strategy._can_refresh = False
+        strategy._can_refresh = False  # pyright: ignore[reportPrivateUsage]
 
         callback = strategy.get_refresh_callback()
         assert callback is None

--- a/tests/unit/testing/unit/mocks/test_config.py
+++ b/tests/unit/testing/unit/mocks/test_config.py
@@ -17,7 +17,7 @@ class TestMockConfigProvider:
         """Test that MockConfigProvider initializes correctly."""
         config_data = {"hostname": "test.example.com", "timeout": 30}
         provider = MockConfigProvider(config_data=config_data)
-        assert provider._config_data == config_data
+        assert provider._config_data == config_data  # pyright: ignore[reportPrivateUsage]
 
     def test_load(self) -> None:
         """Test that load() returns the config data provided during initialization."""


### PR DESCRIPTION
## Summary
- suppress pyright `reportPrivateUsage` warnings in tests
- add ignores in auth mocks used for test scenarios

## Testing
- `pre-commit run --files tests/component/test_enhanced_auth_mocks_refresh.py tests/component/test_phase2_cross_component_integration.py tests/integration/test_tripletex_auth_refresh.py tests/unit/auth/strategies/test_bearer.py tests/unit/auth/strategies/test_custom.py tests/unit/auth/test_auth_base.py tests/unit/testing/mocks/test_enhanced_auth_mocks.py tests/unit/testing/unit/mocks/test_config.py apiconfig/testing/unit/mocks/auth.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68498b138b2883329623f9ac42bd24e9