### PR TITLE
Add pytest typing stubs

### DIFF
--- a/typings/pytest/__init__.pyi
+++ b/typings/pytest/__init__.pyi
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from _pytest.fixtures import fixture
+from _pytest.mark import MARK_GEN as mark
+from _pytest.python_api import raises
+from _pytest.monkeypatch import MonkeyPatch
+from _pytest.outcomes import fail, importorskip, skip
+
+parametrize = mark.parametrize
+
+__all__ = [
+    "fixture",
+    "mark",
+    "parametrize",
+    "raises",
+    "MonkeyPatch",
+    "fail",
+    "skip",
+    "importorskip",
+]


### PR DESCRIPTION
## Summary
- add minimal pytest typing stub to enable pyright type discovery
- keep existing `stubPath` for pyright

## Testing
- `poetry run pytest tests/unit/`
- `poetry run pytest tests/component/`
- `poetry run pytest tests/integration/`
- `poetry run pytest`
- `poetry run pre-commit run --files typings/pytest/__init__.pyi`
- `poetry run pyright`

------
https://chatgpt.com/codex/tasks/task_e_68499821ada883329553e85989e5e382