### PR TITLE
Expose counters for mock refresh

### DIFF
--- a/apiconfig/testing/unit/mocks/auth.py
+++ b/apiconfig/testing/unit/mocks/auth.py
@@ -392,6 +392,25 @@ class MockBearerAuthWithRefresh(MockRefreshableAuthStrategy):
         """
         super().__init__(**kwargs)
 
+    @property
+    def concurrent_refreshes(self) -> int:
+        """Current number of concurrent refresh operations."""
+        return getattr(self, "_concurrent_refreshes", 0)
+
+    @property
+    def max_concurrent_refreshes(self) -> int:
+        """Maximum number of concurrent refresh operations observed."""
+        return getattr(self, "_max_concurrent_refreshes", 0)
+
+    def reset_refresh_counters(self) -> None:
+        """Reset counters tracking refresh attempts and concurrency."""
+        if hasattr(self, "_refresh_attempts"):
+            self._refresh_attempts = 0
+        if hasattr(self, "_concurrent_refreshes"):
+            self._concurrent_refreshes = 0
+        if hasattr(self, "_max_concurrent_refreshes"):
+            self._max_concurrent_refreshes = 0
+
     def apply_auth(self, headers: Dict[str, str]) -> None:
         """Apply Bearer authentication to headers.
 
@@ -579,7 +598,7 @@ class AuthTestScenarioBuilder:
             assert lock is not None
             with lock:
                 strategy._concurrent_refreshes += 1  # pyright: ignore[reportPrivateUsage]
-                strategy._max_concurrent_refreshes = max(
+                strategy._max_concurrent_refreshes = max(  # pyright: ignore[reportPrivateUsage]
                     strategy._max_concurrent_refreshes,  # pyright: ignore[reportPrivateUsage]
                     strategy._concurrent_refreshes,  # pyright: ignore[reportPrivateUsage]
                 )

--- a/tests/component/test_enhanced_auth_mocks_refresh.py
+++ b/tests/component/test_enhanced_auth_mocks_refresh.py
@@ -197,8 +197,6 @@ class TestEnhancedAuthMocksRefresh:
 
         # Test that strategy has thread safety attributes
         assert hasattr(strategy, "_refresh_lock")
-        assert hasattr(strategy, "_concurrent_refreshes")
-        assert hasattr(strategy, "_max_concurrent_refreshes")
 
         # Test concurrent refresh operations
         results: list[TokenRefreshResult] = []
@@ -226,7 +224,7 @@ class TestEnhancedAuthMocksRefresh:
         # Check results
         assert len(results) == 3
         assert len(errors) == 0
-        assert strategy._max_concurrent_refreshes >= 1  # pyright: ignore[reportPrivateUsage]
+        assert strategy.max_concurrent_refreshes >= 1
 
     def test_auth_test_scenario_builder_crudclient_integration(self) -> None:
         """Test AuthTestScenarioBuilder crudclient integration scenario."""

--- a/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
+++ b/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
@@ -386,10 +386,8 @@ class TestAuthTestScenarioBuilder:
 
         # Check that thread safety attributes are added
         assert hasattr(strategy, "_refresh_lock")  # pyright: ignore[reportPrivateUsage]
-        assert hasattr(strategy, "_concurrent_refreshes")  # pyright: ignore[reportPrivateUsage]
-        assert hasattr(strategy, "_max_concurrent_refreshes")  # pyright: ignore[reportPrivateUsage]
-        assert getattr(strategy, "_concurrent_refreshes", None) == 0  # pyright: ignore[reportPrivateUsage]
-        assert getattr(strategy, "_max_concurrent_refreshes", None) == 0  # pyright: ignore[reportPrivateUsage]
+        assert strategy.concurrent_refreshes == 0
+        assert strategy.max_concurrent_refreshes == 0
 
     def test_concurrent_refresh_tracking(self) -> None:
         """Test concurrent refresh tracking functionality."""
@@ -410,8 +408,8 @@ class TestAuthTestScenarioBuilder:
             thread.join()
 
         # Check that concurrent refreshes were tracked
-        assert getattr(strategy, "_concurrent_refreshes", None) == 0  # Should be back to 0
-        assert getattr(strategy, "_max_concurrent_refreshes", 0) >= 1  # At least 1 concurrent
+        assert strategy.concurrent_refreshes == 0
+        assert strategy.max_concurrent_refreshes >= 1
 
     def test_create_crudclient_integration_scenario(self) -> None:
         """Test creating crudclient integration scenario."""
@@ -651,7 +649,7 @@ class TestIntegrationScenarios:
         assert len(results) == 5
 
         # Check that concurrent tracking worked
-        assert getattr(strategy, "_max_concurrent_refreshes", 0) >= 1
+        assert strategy.max_concurrent_refreshes >= 1
 
 
 class TestMockAuthStrategyExceptionHandling:


### PR DESCRIPTION
## Summary
- add properties for concurrent refresh counters in `MockBearerAuthWithRefresh`
- update tests to use the new properties

## Testing
- `poetry run pre-commit run --files apiconfig/testing/unit/mocks/auth.py tests/component/test_enhanced_auth_mocks_refresh.py tests/unit/testing/mocks/test_enhanced_auth_mocks.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849981f0c3c8332a55064f6196eaefb