### PR TITLE
Expose token storage property

### DIFF
--- a/apiconfig/auth/token/storage.py
+++ b/apiconfig/auth/token/storage.py
@@ -73,6 +73,11 @@ class InMemoryTokenStorage(TokenStorage):
         """Initialize the in-memory storage dictionary."""
         self._storage: Dict[str, TokenData] = {}
 
+    @property
+    def storage(self) -> Dict[str, TokenData]:
+        """Return the internal storage dictionary."""
+        return self._storage
+
     def store_token(self, key: str, token_data: TokenData) -> None:
         """
         Store token data in the internal dictionary.

--- a/tests/unit/auth/token/test_storage.py
+++ b/tests/unit/auth/token/test_storage.py
@@ -25,17 +25,17 @@ class TestInMemoryTokenStorage:
     def test_init(self) -> None:
         """Test that InMemoryTokenStorage initializes with an empty storage dict."""
         storage = InMemoryTokenStorage()
-        assert storage._storage == {}
+        assert storage.storage == {}
 
     def test_store_token(self) -> None:
         """Test storing a token."""
         storage = InMemoryTokenStorage()
         storage.store_token("test_key", {"access_token": "test_token"})
-        assert storage._storage["test_key"] == {"access_token": "test_token"}
+        assert storage.storage["test_key"] == {"access_token": "test_token"}
 
         # Test overwriting an existing token
         storage.store_token("test_key", {"access_token": "new_token"})
-        assert storage._storage["test_key"] == {"access_token": "new_token"}
+        assert storage.storage["test_key"] == {"access_token": "new_token"}
 
     def test_retrieve_token(self) -> None:
         """Test retrieving a token."""
@@ -57,9 +57,9 @@ class TestInMemoryTokenStorage:
 
         # Test deleting an existing token
         storage.store_token("test_key", {"access_token": "test_token"})
-        assert "test_key" in storage._storage
+        assert "test_key" in storage.storage
         storage.delete_token("test_key")
-        assert "test_key" not in storage._storage
+        assert "test_key" not in storage.storage
 
     def test_store_and_retrieve_complex_token_data(self) -> None:
         """Test storing and retrieving complex token data (dict)."""


### PR DESCRIPTION
## Summary
- expose a read-only `storage` property for `InMemoryTokenStorage`
- use the new property in tests

## Testing
- `poetry run pytest tests/unit/auth/token/test_storage.py`
- `poetry run pre-commit run --files apiconfig/auth/token/storage.py tests/unit/auth/token/test_storage.py`
- `poetry run tox` *(fails: InterpreterNotFound: python3.13)*

------
https://chatgpt.com/codex/tasks/task_e_6849981e83748332919f70abdf8169a2