### PR TITLE
Add ServerLogEntry TypeAlias

### DIFF
--- a/apiconfig/testing/integration/servers.py
+++ b/apiconfig/testing/integration/servers.py
@@ -15,10 +15,12 @@ These utilities are particularly useful for:
 - Validating error handling in API client code
 """
 import json
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional, TypeAlias, Union
 
 from pytest_httpserver import HTTPServer, RequestHandler
-from werkzeug.wrappers import Response
+from werkzeug.wrappers import Request, Response
+
+ServerLogEntry: TypeAlias = tuple[Request, Response]
 
 
 def configure_mock_response(
@@ -165,10 +167,10 @@ def assert_request_received(
     AssertionError
         If the expected request(s) were not found in the server log.
     """
-    matching_requests: List[Tuple[Any, Response]] = []
+    matching_requests: list[ServerLogEntry] = []
     lower_expected_headers: dict[str, str] | None = {k.lower(): v for k, v in expected_headers.items()} if expected_headers else None
 
-    log = httpserver.log
+    log: list[ServerLogEntry] = httpserver.log
     for entry in log:
         request = entry[0]  # entry is a tuple (request, response)
         if request.path == path and request.method == method:


### PR DESCRIPTION
## Summary
- define `ServerLogEntry` type alias in test helpers
- improve type hints on server log inspection helpers

## Testing
- `poetry run pre-commit run --files apiconfig/testing/integration/servers.py`

------
https://chatgpt.com/codex/tasks/task_e_6849981c57148332b6b17ecad5a83829