### PR TITLE
Replace lambda with helper in tests

### DIFF
--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -21,7 +21,10 @@ class TestVersion:
     def test_version_uses_metadata_when_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """__version__ should use the value from package metadata when available."""
 
-        monkeypatch.setattr(importlib.metadata, "version", lambda _name: "1.2.3")
+        def _fake_version(_name: str) -> str:
+            return "1.2.3"
+
+        monkeypatch.setattr(importlib.metadata, "version", _fake_version)
 
         module = importlib.reload(importlib.import_module("apiconfig"))
         assert module.__version__ == "1.2.3"


### PR DESCRIPTION
## Summary
- add typed helper `_fake_version` for monkeypatch

## Testing
- `poetry run pyright tests/unit/test_version.py`
- `poetry run pre-commit run --files tests/unit/test_version.py`

------
https://chatgpt.com/codex/tasks/task_e_684a595a2d1483328176c9ccb1979619