### PR TITLE
Fix protocol test cast

### DIFF
--- a/tests/unit/test_exception_protocols.py
+++ b/tests/unit/test_exception_protocols.py
@@ -80,7 +80,8 @@ class TestProtocolCompliance:
         # Simple object that happens to have the right attributes
         request = type("Request", (), {"method": "PUT", "url": "https://api.example.com/resource/123", "headers": {}})()
 
-        error = ApiClientError("Update failed", request=request)
+        request_obj: HttpRequestProtocol = cast(HttpRequestProtocol, request)
+        error = ApiClientError("Update failed", request=request_obj)
         assert error.method == "PUT"
         assert error.url == "https://api.example.com/resource/123"
 


### PR DESCRIPTION
## Summary
- ensure request objects are cast to `HttpRequestProtocol`
- run pre-commit checks and pyright on the updated test file

## Testing
- `poetry run pyright tests/unit/test_exception_protocols.py`
- `poetry run pre-commit run --files tests/unit/test_exception_protocols.py`
- `poetry run pytest tests/unit/test_exception_protocols.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684a595ab3848332b84667d4a4056c9a