### PR TITLE
Annotate lists with explicit element types

### DIFF
--- a/apiconfig/testing/unit/mocks/auth.py
+++ b/apiconfig/testing/unit/mocks/auth.py
@@ -271,7 +271,7 @@ class MockRefreshableAuthStrategy(MockAuthStrategy):
         self._concurrent_refreshes = 0
         self._max_concurrent_refreshes = 0
         self._callback_calls = 0
-        self._callback_errors = []
+        self._callback_errors: list[Exception] = []
 
     @property
     def refresh_attempts(self) -> int:

--- a/tests/component/test_refresh_error_handling.py
+++ b/tests/component/test_refresh_error_handling.py
@@ -67,8 +67,8 @@ class TestRefreshErrorHandling:
 
         auth = TestBearerAuth(access_token="initial", http_request_callable=mock_http)
 
-        results = []
-        errors = []
+        results: list[TokenRefreshResult] = []
+        errors: list[Exception] = []
 
         def refresh_worker() -> None:
             try:

--- a/tests/integration/test_tripletex_auth_refresh.py
+++ b/tests/integration/test_tripletex_auth_refresh.py
@@ -13,6 +13,8 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from _pytest.logging import LogCaptureFixture
 
+from apiconfig.types import TokenRefreshResult
+
 if os.getenv("PYTEST_SKIP_INTEGRATION", "false").lower() == "true":
     pytest.skip(
         "Integration tests disabled (PYTEST_SKIP_INTEGRATION=true)",
@@ -119,8 +121,8 @@ class TestTripletexAuthRefresh:
         countries = tripletex_client.list_countries()
         assert isinstance(countries, dict)
 
-        results = []
-        errors = []
+        results: list[TokenRefreshResult | None] = []
+        errors: list[Exception] = []
 
         def refresh_worker() -> None:
             try:
@@ -130,7 +132,7 @@ class TestTripletexAuthRefresh:
                 errors.append(e)
 
         # Start multiple refresh operations concurrently
-        threads = []
+        threads: list[threading.Thread] = []
         for _ in range(3):
             thread = threading.Thread(target=refresh_worker)
             threads.append(thread)

--- a/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
+++ b/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
@@ -397,7 +397,7 @@ class TestAuthTestScenarioBuilder:
             strategy.refresh()
 
         # Start multiple threads
-        threads = []
+        threads: list[threading.Thread] = []
         for _ in range(3):
             thread = threading.Thread(target=refresh_worker)
             threads.append(thread)
@@ -634,7 +634,7 @@ class TestIntegrationScenarios:
                 errors.append(e)
 
         # Start multiple threads
-        threads = []
+        threads: list[threading.Thread] = []
         for _ in range(5):
             thread = threading.Thread(target=worker)
             threads.append(thread)


### PR DESCRIPTION
## Summary
- add element types for results, errors, and threads lists
- type _callback_errors list in auth mock

## Testing
- `poetry run pre-commit run --files apiconfig/testing/unit/mocks/auth.py tests/component/test_refresh_error_handling.py tests/integration/test_tripletex_auth_refresh.py tests/unit/testing/mocks/test_enhanced_auth_mocks.py`
- `poetry run pyright tests/component/test_refresh_error_handling.py`


------
https://chatgpt.com/codex/tasks/task_e_684a595bfcbc83329bab9c3313cc27b3