### PR TITLE
feat: expose config providers

### DIFF
--- a/apiconfig/config/manager.py
+++ b/apiconfig/config/manager.py
@@ -70,6 +70,11 @@ class ConfigManager:
         # typing without leaking concrete provider details to consumers.
         self._providers: Sequence[ConfigProvider] = list(providers)
 
+    @property
+    def providers(self) -> Sequence[ConfigProvider]:
+        """Return the configured providers."""
+        return self._providers
+
     def load_config(self) -> Dict[str, Any]:
         """
         Load configuration by iterating through all registered providers.

--- a/tests/unit/testing/integration/test_helpers.py
+++ b/tests/unit/testing/integration/test_helpers.py
@@ -219,9 +219,9 @@ class TestSetupMultiProviderManager:
         assert isinstance(manager, ConfigManager)
 
         # Check that the manager has two providers
-        assert len(manager._providers) == 2
+        assert len(manager.providers) == 2
 
-        providers = cast(Sequence[Any], manager._providers)
+        providers = cast(Sequence[Any], manager.providers)
 
         # Check that the providers are MemoryProviders with the correct data and names
         assert providers[0]._config == {"api": {"hostname": "example1.com"}}
@@ -236,7 +236,7 @@ class TestSetupMultiProviderManager:
 
         # Check that the result is a ConfigManager with no providers
         assert isinstance(manager, ConfigManager)
-        assert len(manager._providers) == 0
+        assert len(manager.providers) == 0
 
 
 class TestSimulateTokenEndpoint:


### PR DESCRIPTION
## Summary
- expose `providers` property from `ConfigManager`
- update integration helper tests for new property

## Testing
- `pre-commit run --files apiconfig/config/manager.py tests/unit/testing/integration/test_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_684a595c0b38833282b58ae3671894ae