### PR TITLE
Fix pyright private usage warnings in base client tests

### DIFF
--- a/tests/unit/helpers/common/test_base_client.py
+++ b/tests/unit/helpers/common/test_base_client.py
@@ -31,13 +31,13 @@ def test_handle_response_raises_on_error_status() -> None:
     client = _make_client()
     response = httpx.Response(status_code=404, text="not found")
     with pytest.raises(HTTPUtilsError):
-        client._handle_response(response, HttpMethod.GET, "https://example.com/test")
+        client._handle_response(response, HttpMethod.GET, "https://example.com/test")  # pyright: ignore[reportPrivateUsage]
 
 
 def test_handle_response_parses_json() -> None:
     client = _make_client()
     response = httpx.Response(status_code=200, json={"ok": True})
-    result = client._handle_response(response, HttpMethod.GET, "https://example.com/test")
+    result = client._handle_response(response, HttpMethod.GET, "https://example.com/test")  # pyright: ignore[reportPrivateUsage]
     assert result == {"ok": True}
 
 
@@ -45,7 +45,7 @@ def test_handle_response_invalid_json() -> None:
     client = _make_client()
     response = httpx.Response(status_code=200, text="{invalid json")
     with pytest.raises(JSONDecodeError):
-        client._handle_response(response, HttpMethod.GET, "https://example.com/test")
+        client._handle_response(response, HttpMethod.GET, "https://example.com/test")  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.mark.parametrize("body", ["", "null", "123", '"text"'])
@@ -53,5 +53,5 @@ def test_handle_response_empty_or_non_object_returns_empty_dict(body: str) -> No
     """Non-object JSON bodies should result in an empty dict."""
     client = _make_client()
     response = httpx.Response(status_code=200, text=body)
-    result = client._handle_response(response, HttpMethod.GET, "https://example.com/test")
+    result = client._handle_response(response, HttpMethod.GET, "https://example.com/test")  # pyright: ignore[reportPrivateUsage]
     assert result == {}


### PR DESCRIPTION
## Summary
- ignore protected member access in `test_base_client`

## Testing
- `pre-commit run --files tests/unit/helpers/common/test_base_client.py`
- `poetry run pyright tests/unit/helpers/common/test_base_client.py`

------
https://chatgpt.com/codex/tasks/task_e_684a595cba508332899e0c874d40dfd9