### PR TITLE
Update typing in enhanced auth mocks tests

### DIFF
--- a/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
+++ b/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
@@ -3,7 +3,7 @@
 
 import threading
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 from unittest.mock import patch
 
 import pytest
@@ -385,7 +385,7 @@ class TestAuthTestScenarioBuilder:
         strategy = AuthTestScenarioBuilder.create_concurrent_refresh_scenario()
 
         # Check that thread safety attributes are added
-        assert hasattr(strategy, "_refresh_lock")  # pyright: ignore[reportPrivateUsage]
+        assert hasattr(strategy, "_refresh_lock")
         assert strategy.concurrent_refreshes == 0
         assert strategy.max_concurrent_refreshes == 0
 
@@ -397,7 +397,7 @@ class TestAuthTestScenarioBuilder:
             strategy.refresh()
 
         # Start multiple threads
-        threads = []
+        threads: list[threading.Thread] = []
         for _ in range(3):
             thread = threading.Thread(target=refresh_worker)
             threads.append(thread)
@@ -622,8 +622,8 @@ class TestIntegrationScenarios:
         strategy = AuthTestScenarioBuilder.create_concurrent_refresh_scenario()
         callback = strategy.get_refresh_callback()
 
-        results: List[str] = []
-        errors: List[Exception] = []
+        results: list[str] = []
+        errors: list[Exception] = []
 
         def worker() -> None:
             try:
@@ -634,7 +634,7 @@ class TestIntegrationScenarios:
                 errors.append(e)
 
         # Start multiple threads
-        threads = []
+        threads: list[threading.Thread] = []
         for _ in range(5):
             thread = threading.Thread(target=worker)
             threads.append(thread)


### PR DESCRIPTION
## Summary
- remove unnecessary pyright ignore comment in test_enhanced_auth_mocks
- annotate threads, results, and errors using builtin generics

## Testing
- `poetry run pyright tests/unit/testing/mocks/test_enhanced_auth_mocks.py`
- `poetry run pre-commit run --files tests/unit/testing/mocks/test_enhanced_auth_mocks.py`

------
https://chatgpt.com/codex/tasks/task_e_684a595e47e483328d5c69bfff54f5f5