### PR TITLE
Fix token storage retrieval pyright error

### DIFF
--- a/tests/unit/auth/token/test_storage.py
+++ b/tests/unit/auth/token/test_storage.py
@@ -74,6 +74,7 @@ class TestInMemoryTokenStorage:
         storage.store_token("complex", token_data)
         retrieved = storage.retrieve_token("complex")
 
+        assert retrieved is not None
         assert retrieved == token_data
         assert retrieved["access_token"] == "abc123"
         assert retrieved["refresh_token"] == "xyz789"


### PR DESCRIPTION
## Summary
- prevent optional subscript warning in token storage unit test

## Testing
- `pre-commit run --files tests/unit/auth/token/test_storage.py`
- `poetry run pyright`

------
https://chatgpt.com/codex/tasks/task_e_684a94cdfe388332aea4df16d284baef