### PR TITLE
Expose file path property

### DIFF
--- a/apiconfig/config/providers/file.py
+++ b/apiconfig/config/providers/file.py
@@ -34,6 +34,11 @@ class FileProvider:
         """
         self._file_path = pathlib.Path(file_path)
 
+    @property
+    def file_path(self) -> pathlib.Path:
+        """Return the path to the configuration file."""
+        return self._file_path
+
     def load(self) -> Dict[str, Any]:
         """
         Load configuration data from the specified file.

--- a/tests/unit/config/providers/test_file.py
+++ b/tests/unit/config/providers/test_file.py
@@ -21,13 +21,13 @@ class TestFileProvider:
         """Test that FileProvider initializes correctly with string or Path."""
         # Test with string path
         provider1 = FileProvider(file_path="/path/to/config.json")
-        assert isinstance(provider1._file_path, pathlib.Path)
-        assert os.path.normpath(str(provider1._file_path)) == os.path.normpath("/path/to/config.json")
+        assert isinstance(provider1.file_path, pathlib.Path)
+        assert os.path.normpath(str(provider1.file_path)) == os.path.normpath("/path/to/config.json")
 
         # Test with Path object
         path_obj = Path("/path/to/config.json")
         provider2 = FileProvider(file_path=path_obj)
-        assert os.path.normpath(str(provider2._file_path)) == os.path.normpath(str(path_obj))
+        assert os.path.normpath(str(provider2.file_path)) == os.path.normpath(str(path_obj))
 
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="Known Windows compatibility issue")
     def test_load_valid_json(self) -> None:

--- a/tests/unit/testing/integration/test_fixtures.py
+++ b/tests/unit/testing/integration/test_fixtures.py
@@ -102,7 +102,7 @@ class TestFileProvider:
 
         # Check that the provider is a FileProvider with the correct file path
         assert isinstance(provider, FileProvider)
-        assert provider._file_path == config_file
+        assert provider.file_path == config_file
 
 
 class TestEnvProvider:


### PR DESCRIPTION
## Summary
- add read-only property `file_path` to `FileProvider`
- use the new property in tests instead of `_file_path`

## Testing
- `poetry run pre-commit run --files apiconfig/config/providers/file.py tests/unit/config/providers/test_file.py tests/unit/testing/integration/test_fixtures.py`
- `poetry run pyright`

------
https://chatgpt.com/codex/tasks/task_e_684a94c8b2bc83329a1fc3526f442bc0