### PR TITLE
Fix pyright warning in integration test

### DIFF
--- a/tests/integration/test_apiconfig_oneflow.py
+++ b/tests/integration/test_apiconfig_oneflow.py
@@ -123,13 +123,16 @@ class TestOneFlowIntegration:
         contracts = oneflow_client.list_contracts()
 
         # OneFlow may return different structures, handle both cases
+        assert isinstance(contracts, (list, dict)), f"Unexpected response type: {type(contracts)}"
         if isinstance(contracts, dict):
-            # Dict response with data key
-            if "data" in contracts:
-                assert isinstance(contracts["data"], list)
-        elif isinstance(contracts, list):
-            # Direct list response
-            assert len(contracts) >= 0  # May be empty
+            assert "data" in contracts, f"Response dict missing 'data' key: {contracts.keys()}"
+            contracts_list = contracts.get("data", [])
+            assert isinstance(contracts_list, list)
+        else:
+            contracts_list = contracts
+
+        if contracts_list:
+            assert isinstance(contracts_list[0], dict)
 
     def test_configuration_validation(self) -> None:
         """Test that proper configuration validation occurs.


### PR DESCRIPTION
## Summary
- clean up redundant isinstance check in integration test

## Testing
- `pre-commit run --files tests/integration/test_apiconfig_oneflow.py`
- `poetry run pyright tests/integration/test_apiconfig_oneflow.py`

------
https://chatgpt.com/codex/tasks/task_e_684a94cb236483328a18006ccb1c4714