### PR TITLE
Add request wrapper to BaseClient

### DIFF
--- a/helpers_for_tests/common/base_client.py
+++ b/helpers_for_tests/common/base_client.py
@@ -201,6 +201,23 @@ class BaseClient:
         except Exception as e:
             raise HTTPUtilsError(f"Unexpected error during request to {method.value} {url}: {e}") from e
 
+    def request(
+        self,
+        method: HttpMethod,
+        endpoint: str,
+        params: Optional[QueryParamType] = None,
+        json_data: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> JsonObject | JsonList:
+        """Public wrapper for :py:meth:`_request`."""
+        return self._request(
+            method=method,
+            endpoint=endpoint,
+            params=params,
+            json_data=json_data,
+            **kwargs,
+        )
+
     def __repr__(self) -> str:
         """Return string representation of the client."""
         return (

--- a/tests/integration/test_apiconfig_fiken.py
+++ b/tests/integration/test_apiconfig_fiken.py
@@ -99,7 +99,7 @@ class TestFikenIntegration:
     def test_error_handling_with_http_utilities(self, fiken_client: FikenClient) -> None:
         """Test that API errors are handled appropriately using HTTP utilities."""
         with pytest.raises(HTTPUtilsError) as exc_info:
-            fiken_client._request(HttpMethod.GET, "/nonexistent")
+            fiken_client.request(HttpMethod.GET, "/nonexistent")
 
         error_message = str(exc_info.value)
         assert "HTTP request" in error_message or "failed" in error_message.lower()

--- a/tests/integration/test_apiconfig_oneflow.py
+++ b/tests/integration/test_apiconfig_oneflow.py
@@ -169,7 +169,7 @@ class TestOneFlowIntegration:
         """
         # Test with invalid endpoint to trigger error handling
         with pytest.raises(HTTPUtilsError) as exc_info:
-            oneflow_client._request(HttpMethod.GET, "/nonexistent")
+            oneflow_client.request(HttpMethod.GET, "/nonexistent")
 
         # Verify we get proper apiconfig HTTP exceptions
         error_message = str(exc_info.value)

--- a/tests/integration/test_apiconfig_tripletex.py
+++ b/tests/integration/test_apiconfig_tripletex.py
@@ -180,7 +180,7 @@ class TestTripletexIntegration:
         """
         # Test with invalid endpoint to trigger error handling
         with pytest.raises(HTTPUtilsError) as exc_info:
-            tripletex_client._request(HttpMethod.GET, "/nonexistent")
+            tripletex_client.request(HttpMethod.GET, "/nonexistent")
 
         # Verify we get proper apiconfig HTTP exceptions
         error_message = str(exc_info.value)


### PR DESCRIPTION
## Summary
- add public request() wrapper in BaseClient
- use request() in integration tests to avoid protected access warnings

## Testing
- `pre-commit run --files helpers_for_tests/common/base_client.py tests/integration/test_apiconfig_fiken.py tests/integration/test_apiconfig_oneflow.py tests/integration/test_apiconfig_tripletex.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a94cadbc08332b1d7c5313e632dc8