### PR TITLE
Update tests to use ConfigManager.providers

### DIFF
--- a/tests/unit/config/test_manager.py
+++ b/tests/unit/config/test_manager.py
@@ -65,7 +65,7 @@ class TestConfigManager:
         """Test that ConfigManager initializes correctly."""
         providers = [MockProvider(), MockProvider()]
         manager = ConfigManager(providers=providers)
-        assert manager._providers == providers
+        assert manager.providers == providers
 
     def test_load_config_empty_providers(self) -> None:
         """Test loading config with no providers."""

--- a/tests/unit/testing/integration/test_fixtures.py
+++ b/tests/unit/testing/integration/test_fixtures.py
@@ -145,7 +145,7 @@ class TestConfigManager:
 
         # Check that the manager is a ConfigManager with the correct providers
         assert isinstance(manager, ConfigManager)
-        assert manager._providers == [mock_file_provider, mock_env_provider]
+        assert manager.providers == [mock_file_provider, mock_env_provider]
 
 
 class TestCustomAuthStrategyFactory:


### PR DESCRIPTION
## Summary
- use the public `providers` property in unit tests

## Testing
- `poetry run pyright tests/unit/config/test_manager.py tests/unit/testing/integration/test_fixtures.py`
- `poetry run pytest tests/unit/config/test_manager.py tests/unit/testing/integration/test_fixtures.py -q`
- `poetry run pre-commit run --files tests/unit/config/test_manager.py tests/unit/testing/integration/test_fixtures.py`

------
https://chatgpt.com/codex/tasks/task_e_684a94c9534c83328e2b9c7134b57269