### PR TITLE
Expose EnvProvider prefix

### DIFF
--- a/apiconfig/config/providers/env.py
+++ b/apiconfig/config/providers/env.py
@@ -36,7 +36,12 @@ class EnvProvider:
         """
         self._prefix = prefix
 
-    def _is_digit(self, value: str) -> bool:
+    @property
+    def prefix(self) -> str:
+        """Return the environment variable prefix."""
+        return self._prefix
+
+    def is_digit(self, value: str) -> bool:
         """Check if a string contains only digits.
 
         Parameters
@@ -78,7 +83,7 @@ class EnvProvider:
             if key.startswith(self._prefix):
                 config_key = key[prefix_len:]  # Keep original case after removing prefix
                 # Basic type inference (can be expanded later)
-                if self._is_digit(value):
+                if self.is_digit(value):
                     try:
                         config[config_key] = int(value)
                     except ValueError:

--- a/tests/unit/config/providers/test_env.py
+++ b/tests/unit/config/providers/test_env.py
@@ -29,11 +29,11 @@ class TestEnvProvider:
     def test_init(self) -> None:
         """Test that EnvProvider initializes correctly with custom prefix."""
         provider = EnvProvider(prefix="TEST_")
-        assert provider._prefix == "TEST_"
+        assert provider.prefix == "TEST_"
 
         # Test default prefix
         default_provider = EnvProvider()
-        assert default_provider._prefix == "APICONFIG_"
+        assert default_provider.prefix == "APICONFIG_"
 
     def test_load_empty(self) -> None:
         """Test loading when no matching environment variables exist."""
@@ -62,14 +62,14 @@ class TestEnvProvider:
     def test_load_invalid_int(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test loading with an invalid integer value."""
         # Instead of trying to mock str.isdigit (which is immutable),
-        # we'll mock the EnvProvider._is_digit method
+        # we'll mock the EnvProvider.is_digit method
 
         # First, add a helper method to the EnvProvider class
-        def _is_digit(self: EnvProvider, value: str) -> bool:
+        def is_digit(self: EnvProvider, value: str) -> bool:
             return value.isdigit()
 
         # Add the method to the class
-        monkeypatch.setattr(EnvProvider, "_is_digit", _is_digit)
+        monkeypatch.setattr(EnvProvider, "is_digit", is_digit)
 
         # Now mock our new method
         def mock_is_digit(self: EnvProvider, value: str) -> bool:
@@ -77,18 +77,18 @@ class TestEnvProvider:
                 return True
             return value.isdigit()
 
-        monkeypatch.setattr(EnvProvider, "_is_digit", mock_is_digit)
+        monkeypatch.setattr(EnvProvider, "is_digit", mock_is_digit)
 
-        # Also need to patch the load method to use our new _is_digit method
+        # Also need to patch the load method to use our new is_digit method
 
         def patched_load(self: EnvProvider) -> Dict[str, Any]:
             config: Dict[str, Any] = {}
-            prefix_len = len(self._prefix)
+            prefix_len = len(self.prefix)
 
             for key, value in os.environ.items():
-                if key.startswith(self._prefix):
+                if key.startswith(self.prefix):
                     config_key = key[prefix_len:]
-                    if self._is_digit(value):
+                    if self.is_digit(value):
                         try:
                             config[config_key] = int(value)
                         except ValueError:

--- a/tests/unit/testing/integration/test_fixtures.py
+++ b/tests/unit/testing/integration/test_fixtures.py
@@ -126,9 +126,8 @@ class TestEnvProvider:
         assert os.environ.get("APICONFIG_AUTH_TYPE") == "env_bearer"
         assert os.environ.get("APICONFIG_AUTH_TOKEN") == "env_token_123"
 
-        # Check that the provider has the correct prefix
         # Check that the provider has the expected prefix
-        assert hasattr(provider, "_prefix")
+        assert provider.prefix == "APICONFIG"
 
 
 class TestConfigManager:


### PR DESCRIPTION
## Summary
- add `prefix` property to EnvProvider
- rename `_is_digit` to `is_digit`
- update tests to use the public helpers

## Testing
- `pre-commit run --files apiconfig/config/providers/env.py tests/unit/config/providers/test_env.py tests/unit/testing/integration/test_fixtures.py`
- `poetry run pyright`
- `poetry run pytest tests/unit/config/providers/test_env.py tests/unit/testing/integration/test_fixtures.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684a94c81af88332a4fc9922c22849f0