### PR TITLE
Add history to HttpResponseProtocol

### DIFF
--- a/apiconfig/types.py
+++ b/apiconfig/types.py
@@ -77,13 +77,19 @@ class HttpRequestProtocol(Protocol):
 
 @runtime_checkable
 class HttpResponseProtocol(Protocol):
-    """Protocol matching common HTTP response objects (requests.Response, httpx.Response, etc.)."""
+    """Protocol matching common HTTP response objects.
+
+    This includes responses from libraries like :mod:`requests` and
+    :mod:`httpx`. Redirect chains are captured via the optional
+    :attr:`history` attribute when available.
+    """
 
     status_code: int
     headers: Any
     text: str  # For body preview
     request: Optional[Any]  # Most responses have .request
     reason: Optional[str]
+    history: Sequence["HttpResponseProtocol"] | None
 
 
 class HttpMethod(Enum):

--- a/docs/source/http_exception_protocols.rst
+++ b/docs/source/http_exception_protocols.rst
@@ -50,7 +50,7 @@ The library uses Protocol types to define the expected interface:
 
 .. code-block:: python
 
-    from typing import Protocol, Optional, Any, runtime_checkable
+    from typing import Protocol, Optional, Any, Sequence, runtime_checkable
 
     @runtime_checkable
     class HttpRequestProtocol(Protocol):
@@ -67,6 +67,7 @@ The library uses Protocol types to define the expected interface:
         text: str
         request: Optional[Any]
         reason: Optional[str]
+        history: Sequence["HttpResponseProtocol"] | None
 
 Any object that has these attributes will work seamlessly with apiconfig exceptions.
 

--- a/tests/integration/test_apiconfig_fiken.py
+++ b/tests/integration/test_apiconfig_fiken.py
@@ -99,7 +99,7 @@ class TestFikenIntegration:
     def test_error_handling_with_http_utilities(self, fiken_client: FikenClient) -> None:
         """Test that API errors are handled appropriately using HTTP utilities."""
         with pytest.raises(HTTPUtilsError) as exc_info:
-            fiken_client._request(HttpMethod.GET, "/nonexistent")
+            fiken_client._request(HttpMethod.GET, "/nonexistent")  # pyright: ignore[reportPrivateUsage]
 
         error_message = str(exc_info.value)
         assert "HTTP request" in error_message or "failed" in error_message.lower()

--- a/tests/integration/test_apiconfig_oneflow.py
+++ b/tests/integration/test_apiconfig_oneflow.py
@@ -127,7 +127,7 @@ class TestOneFlowIntegration:
             # Dict response with data key
             if "data" in contracts:
                 assert isinstance(contracts["data"], list)
-        elif isinstance(contracts, list):
+        elif isinstance(contracts, list):  # pyright: ignore[reportUnnecessaryIsInstance]
             # Direct list response
             assert len(contracts) >= 0  # May be empty
 
@@ -169,7 +169,7 @@ class TestOneFlowIntegration:
         """
         # Test with invalid endpoint to trigger error handling
         with pytest.raises(HTTPUtilsError) as exc_info:
-            oneflow_client._request(HttpMethod.GET, "/nonexistent")
+            oneflow_client._request(HttpMethod.GET, "/nonexistent")  # pyright: ignore[reportPrivateUsage]
 
         # Verify we get proper apiconfig HTTP exceptions
         error_message = str(exc_info.value)

--- a/tests/integration/test_apiconfig_tripletex.py
+++ b/tests/integration/test_apiconfig_tripletex.py
@@ -180,7 +180,7 @@ class TestTripletexIntegration:
         """
         # Test with invalid endpoint to trigger error handling
         with pytest.raises(HTTPUtilsError) as exc_info:
-            tripletex_client._request(HttpMethod.GET, "/nonexistent")
+            tripletex_client._request(HttpMethod.GET, "/nonexistent")  # pyright: ignore[reportPrivateUsage]
 
         # Verify we get proper apiconfig HTTP exceptions
         error_message = str(exc_info.value)

--- a/tests/integration/test_requests_compatibility.py
+++ b/tests/integration/test_requests_compatibility.py
@@ -175,4 +175,5 @@ class TestRequestsEdgeCases:
 
         # Can access history through original response
         assert exc.response is not None and hasattr(exc.response, "history")
+        assert exc.response.history is not None
         assert len(exc.response.history) == 2

--- a/tests/integration/test_tripletex_auth_refresh.py
+++ b/tests/integration/test_tripletex_auth_refresh.py
@@ -63,9 +63,9 @@ class TestTripletexAuthRefresh:
         assert not auth_strategy.is_expired()
         assert auth_strategy._session_token is not None  # pyright: ignore[reportPrivateUsage]
         # Token should be refreshed (new token)
-        assert auth_strategy._session_token != old_token or auth_strategy._token_expires_at > datetime.now(
+        assert auth_strategy._session_token != old_token or auth_strategy._token_expires_at > datetime.now(  # pyright: ignore[reportPrivateUsage]
             timezone.utc
-        )  # pyright: ignore[reportPrivateUsage]
+        )
 
     def test_refresh_callback_integration(self, tripletex_client: TripletexClient) -> None:
         """Test integration with crudclient-style refresh callback."""

--- a/tests/unit/auth/test_auth_base.py
+++ b/tests/unit/auth/test_auth_base.py
@@ -1,6 +1,6 @@
 """Unit tests for the AuthStrategy base class."""
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, cast
 from unittest.mock import Mock
 
 import pytest
@@ -117,7 +117,7 @@ class TestAuthStrategy:
 
         # Replace the refresh method with our mock
         original_refresh = strategy.refresh
-        strategy.refresh = refresh_mock  # type: ignore
+        cast(Any, strategy).refresh = refresh_mock
 
         callback = strategy.get_refresh_callback()
         assert callback is not None
@@ -129,7 +129,7 @@ class TestAuthStrategy:
         refresh_mock.assert_called_once()
 
         # Restore original method
-        strategy.refresh = original_refresh  # type: ignore
+        cast(Any, strategy).refresh = original_refresh
 
     def test_refreshable_strategy_can_refresh_with_http_callable(self) -> None:
         """Test that RefreshableAuthStrategy can refresh when http_request_callable is provided."""

--- a/tests/unit/auth/token/test_refresh.py
+++ b/tests/unit/auth/token/test_refresh.py
@@ -59,8 +59,8 @@ class TestRefreshOAuth2Token:
 
         # Verify the request was made correctly
         mock_http_client.post.assert_called_once()
-        args, kwargs = mock_http_client.post.call_args
-        assert args[0] == "https://example.com/token"
+        _args, kwargs = mock_http_client.post.call_args
+        assert _args[0] == "https://example.com/token"
         assert kwargs["data"]["grant_type"] == "refresh_token"
         assert kwargs["data"]["refresh_token"] == "test_refresh_token"
         assert kwargs["timeout"] == 10.0  # Default timeout
@@ -83,7 +83,7 @@ class TestRefreshOAuth2Token:
 
         # Verify the request was made with the correct timeout
         mock_http_client.post.assert_called_once()
-        args, kwargs = mock_http_client.post.call_args
+        _args, kwargs = mock_http_client.post.call_args
         assert kwargs["timeout"] == 5.0  # Custom timeout from client_config
 
     def test_refresh_oauth2_token_with_explicit_params(self, mock_http_client: MagicMock, mock_response: MagicMock) -> None:
@@ -102,7 +102,7 @@ class TestRefreshOAuth2Token:
 
         # Verify the request was made with the correct timeout
         mock_http_client.post.assert_called_once()
-        args, kwargs = mock_http_client.post.call_args
+        _args, kwargs = mock_http_client.post.call_args
         assert kwargs["timeout"] == 3.0  # Explicit timeout
 
     def test_refresh_oauth2_token_with_auth_credentials(self, mock_http_client: MagicMock, mock_response: MagicMock) -> None:
@@ -124,7 +124,7 @@ class TestRefreshOAuth2Token:
 
         # Verify the request was made with Basic Auth
         mock_http_client.post.assert_called_once()
-        args, kwargs = mock_http_client.post.call_args
+        _args, kwargs = mock_http_client.post.call_args
         assert "auth" in kwargs
         assert kwargs["auth"] == "basic_auth"
         mock_http_client.BasicAuth.assert_called_once_with(username="test_client_id", password="test_client_secret")
@@ -144,7 +144,7 @@ class TestRefreshOAuth2Token:
 
         # Verify the request was made with the extra parameters
         mock_http_client.post.assert_called_once()
-        args, kwargs = mock_http_client.post.call_args
+        _args, kwargs = mock_http_client.post.call_args
         assert kwargs["data"]["scope"] == "read write"
         assert kwargs["data"]["audience"] == "api://default"
 

--- a/tests/unit/auth/token/test_storage.py
+++ b/tests/unit/auth/token/test_storage.py
@@ -74,6 +74,7 @@ class TestInMemoryTokenStorage:
         storage.store_token("complex", token_data)
         retrieved = storage.retrieve_token("complex")
 
+        assert retrieved is not None
         assert retrieved == token_data
         assert retrieved["access_token"] == "abc123"
         assert retrieved["refresh_token"] == "xyz789"

--- a/tests/unit/config/providers/test_env.py
+++ b/tests/unit/config/providers/test_env.py
@@ -29,11 +29,11 @@ class TestEnvProvider:
     def test_init(self) -> None:
         """Test that EnvProvider initializes correctly with custom prefix."""
         provider = EnvProvider(prefix="TEST_")
-        assert provider._prefix == "TEST_"
+        assert provider._prefix == "TEST_"  # pyright: ignore[reportPrivateUsage]
 
         # Test default prefix
         default_provider = EnvProvider()
-        assert default_provider._prefix == "APICONFIG_"
+        assert default_provider._prefix == "APICONFIG_"  # pyright: ignore[reportPrivateUsage]
 
     def test_load_empty(self) -> None:
         """Test loading when no matching environment variables exist."""
@@ -83,12 +83,12 @@ class TestEnvProvider:
 
         def patched_load(self: EnvProvider) -> Dict[str, Any]:
             config: Dict[str, Any] = {}
-            prefix_len = len(self._prefix)
+            prefix_len = len(self._prefix)  # pyright: ignore[reportPrivateUsage]
 
             for key, value in os.environ.items():
-                if key.startswith(self._prefix):
+                if key.startswith(self._prefix):  # pyright: ignore[reportPrivateUsage]
                     config_key = key[prefix_len:]
-                    if self._is_digit(value):
+                    if self._is_digit(value):  # pyright: ignore[reportPrivateUsage]
                         try:
                             config[config_key] = int(value)
                         except ValueError:

--- a/tests/unit/config/providers/test_file.py
+++ b/tests/unit/config/providers/test_file.py
@@ -21,13 +21,13 @@ class TestFileProvider:
         """Test that FileProvider initializes correctly with string or Path."""
         # Test with string path
         provider1 = FileProvider(file_path="/path/to/config.json")
-        assert isinstance(provider1._file_path, pathlib.Path)
-        assert os.path.normpath(str(provider1._file_path)) == os.path.normpath("/path/to/config.json")
+        assert isinstance(provider1._file_path, pathlib.Path)  # pyright: ignore[reportPrivateUsage]
+        assert os.path.normpath(str(provider1._file_path)) == os.path.normpath("/path/to/config.json")  # pyright: ignore[reportPrivateUsage]
 
         # Test with Path object
         path_obj = Path("/path/to/config.json")
         provider2 = FileProvider(file_path=path_obj)
-        assert os.path.normpath(str(provider2._file_path)) == os.path.normpath(str(path_obj))
+        assert os.path.normpath(str(provider2._file_path)) == os.path.normpath(str(path_obj))  # pyright: ignore[reportPrivateUsage]
 
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="Known Windows compatibility issue")
     def test_load_valid_json(self) -> None:

--- a/tests/unit/config/test_manager.py
+++ b/tests/unit/config/test_manager.py
@@ -65,7 +65,7 @@ class TestConfigManager:
         """Test that ConfigManager initializes correctly."""
         providers = [MockProvider(), MockProvider()]
         manager = ConfigManager(providers=providers)
-        assert manager._providers == providers
+        assert manager._providers == providers  # pyright: ignore[reportPrivateUsage]
 
     def test_load_config_empty_providers(self) -> None:
         """Test loading config with no providers."""

--- a/tests/unit/test_exception_protocols.py
+++ b/tests/unit/test_exception_protocols.py
@@ -1,6 +1,6 @@
 """Unit tests for HTTP exception protocol support."""
 
-from typing import Any, cast
+from typing import Any, Sequence, cast
 from unittest.mock import Mock
 
 import pytest
@@ -10,7 +10,7 @@ from apiconfig.exceptions.http import (
     ApiClientError,
     create_api_client_error,
 )
-from apiconfig.types import HttpRequestProtocol
+from apiconfig.types import HttpRequestProtocol, HttpResponseProtocol
 
 
 class TestProtocolCompliance:
@@ -42,6 +42,7 @@ class TestProtocolCompliance:
                 self.text = "Not found"
                 self.request = None
                 self.reason: str | None = "Not Found"
+                self.history: Sequence[HttpResponseProtocol] | None = None
 
         response = MinimalResponse()
         # Skip runtime type check that causes mypy issues

--- a/tests/unit/testing/integration/test_fixtures.py
+++ b/tests/unit/testing/integration/test_fixtures.py
@@ -102,7 +102,7 @@ class TestFileProvider:
 
         # Check that the provider is a FileProvider with the correct file path
         assert isinstance(provider, FileProvider)
-        assert provider._file_path == config_file
+        assert provider._file_path == config_file  # pyright: ignore[reportPrivateUsage]
 
 
 class TestEnvProvider:
@@ -145,7 +145,7 @@ class TestConfigManager:
 
         # Check that the manager is a ConfigManager with the correct providers
         assert isinstance(manager, ConfigManager)
-        assert manager._providers == [mock_file_provider, mock_env_provider]
+        assert manager._providers == [mock_file_provider, mock_env_provider]  # pyright: ignore[reportPrivateUsage]
 
 
 class TestCustomAuthStrategyFactory:


### PR DESCRIPTION
## Summary
- support redirect history in `HttpResponseProtocol`
- document new attribute in docs
- fix tests to handle optional history

## Testing
- `pre-commit run --files apiconfig/types.py docs/source/http_exception_protocols.rst tests/integration/test_apiconfig_fiken.py tests/integration/test_apiconfig_oneflow.py tests/integration/test_apiconfig_tripletex.py tests/integration/test_requests_compatibility.py tests/integration/test_tripletex_auth_refresh.py tests/unit/auth/test_auth_base.py tests/unit/auth/token/test_refresh.py tests/unit/auth/token/test_storage.py tests/unit/config/providers/test_env.py tests/unit/config/providers/test_file.py tests/unit/config/test_manager.py tests/unit/test_exception_protocols.py tests/unit/testing/integration/test_fixtures.py`
- `pytest tests/integration/test_requests_compatibility.py`

------
https://chatgpt.com/codex/tasks/task_e_684a94c64cf4833287b08e8c852d2a7d