### PR TITLE
Add README for types module

### DIFF
--- a/apiconfig/types/README.md
+++ b/apiconfig/types/README.md
@@ -1,0 +1,22 @@
+# apiconfig.types
+
+Shared type aliases and protocols for **apiconfig**. They keep the public API
+small and make static analysis consistent across modules.
+
+## Navigation
+- [Project README](../README.md)
+
+## Contents
+- `types.py`
+
+## Usage Examples
+```python
+from apiconfig.types import JsonObject, HeadersType, HttpMethod
+
+headers: HeadersType = {"Authorization": "Bearer secret"}
+method: HttpMethod = HttpMethod.GET
+payload: JsonObject = {"ping": "pong"}
+```
+
+## Status
+Stable – used throughout the library for type checking.


### PR DESCRIPTION
## Summary
- document the `apiconfig.types` module

## Testing
- `poetry run pre-commit run --files apiconfig/types/README.md`

------
https://chatgpt.com/codex/tasks/task_e_684af2697cb083328e84e577d334d57c