### PR TITLE
Add navigation to auth docs

### DIFF
--- a/apiconfig/auth/README.md
+++ b/apiconfig/auth/README.md
@@ -57,3 +57,8 @@ pytest tests/unit/auth -q
 
 ## Status
 Stable – used by the configuration system and tested via the unit suite.
+
+## Navigation
+- [apiconfig](../README.md) – project overview and main documentation.
+- [strategies](./strategies/README.md) – built-in authentication strategies.
+- [token](./token/README.md) – utilities for managing OAuth2 tokens.


### PR DESCRIPTION
## Summary
- link auth docs to parent README and submodules

## Testing
- `poetry run pre-commit run --files apiconfig/auth/README.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684af26c56e48332aac5b95a5a2a6077