### PR TITLE
Update config README with navigation

### DIFF
--- a/apiconfig/config/README.md
+++ b/apiconfig/config/README.md
@@ -57,3 +57,7 @@ pytest tests/unit/config -q
 
 ## Status
 Stable – used by API clients and covered by unit tests.
+
+## Navigation
+- [apiconfig](../README.md)
+- [providers](./providers/README.md)


### PR DESCRIPTION
## Summary
- add Navigation heading in config docs

## Testing
- `poetry run pre-commit run --files apiconfig/config/README.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684af27882b48332b6b090c4285250c0