### PR TITLE
Update logging README with navigation

### DIFF
--- a/apiconfig/utils/logging/README.md
+++ b/apiconfig/utils/logging/README.md
@@ -52,3 +52,10 @@ pytest tests/unit/utils/logging -q
 
 ## Status
 Stable – provides common logging setup for the library.
+
+## Navigation
+
+**Parent Module:** [apiconfig.utils](../README.md)
+
+**Submodules:**
+- [formatters](./formatters/README.md) - Custom log formatters


### PR DESCRIPTION
## Summary
- add navigation section to logging README

## Testing
- `poetry run pre-commit run --files apiconfig/utils/logging/README.md`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af27b646c8332a1b2ac0a4d1ca347