### PR TITLE
docs: add navigation to config providers

### DIFF
--- a/apiconfig/config/providers/README.md
+++ b/apiconfig/config/providers/README.md
@@ -3,6 +3,12 @@
 Configuration providers for **apiconfig**. These helpers supply configuration values from
 different sources so they can be combined by `ConfigManager`.
 
+## Navigation
+
+**Parent Module:** [apiconfig.config](../README.md)
+
+**Submodules:** None
+
 ## Contents
 - `env.py` – load configuration from environment variables with optional type inference.
 - `file.py` – read configuration from JSON files.


### PR DESCRIPTION
## Summary
- document parent link in providers README
- note that this folder has no submodules

## Testing
- `poetry run pre-commit run --files apiconfig/config/providers/README.md`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afd1972c083329c0ba6c114629c0e