### PR TITLE
Add navigation to redaction README

### DIFF
--- a/apiconfig/utils/redaction/README.md
+++ b/apiconfig/utils/redaction/README.md
@@ -2,6 +2,12 @@
 
 Utilities for scrubbing sensitive information from HTTP requests, responses and logs. The package centralises common redaction logic so that clients and logging helpers can easily avoid leaking secrets.
 
+## Navigation
+
+**Parent Module:** [apiconfig.utils](../README.md)
+
+There are no submodules.
+
 ## Contents
 - `body.py` – functions to redact JSON and form-encoded bodies.
 - `headers.py` – utilities to remove secrets from HTTP headers and cookies.


### PR DESCRIPTION
## Summary
- add a Navigation section to `utils/redaction` docs

## Testing
- `poetry run pre-commit run --files apiconfig/utils/redaction/README.md`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afd1e807883328a07c33ae2a75239