### PR TITLE
Update logging docs

### DIFF
--- a/apiconfig/utils/logging/README.md
+++ b/apiconfig/utils/logging/README.md
@@ -21,6 +21,30 @@ logger = logging.getLogger("apiconfig")
 logger.info("configured")
 ```
 
+### Advanced Usage
+Use the building blocks directly when you need full control over handlers and
+formatters.
+
+```python
+import logging
+from apiconfig.utils.logging.formatters import RedactingFormatter
+from apiconfig.utils.logging.handlers import ConsoleHandler
+from apiconfig.utils.logging.filters import ContextFilter, set_log_context
+
+handler = ConsoleHandler()
+handler.setFormatter(
+    RedactingFormatter("%(asctime)s - %(levelname)s - %(message)s")
+)
+handler.addFilter(ContextFilter())
+
+logger = logging.getLogger("custom")
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+set_log_context("request_id", "42")
+logger.info({"token": "secret", "payload": "ok"})
+```
+
 ## Key classes and functions
 | Name | Description |
 | ---- | ----------- |


### PR DESCRIPTION
## Summary
- extend basic example in `apiconfig.utils.logging` docs
- add an advanced snippet showing how to combine handlers, formatters, and filters

## Testing
- `poetry run pytest tests/unit/utils/logging -q`
- `poetry run pre-commit run --files apiconfig/utils/logging/README.md`

------
https://chatgpt.com/codex/tasks/task_e_684afd1b641c8332acd441e21d1d16e7