### PR TITLE
Add changelog to integration helpers docs

### DIFF
--- a/apiconfig/testing/integration/README.md
+++ b/apiconfig/testing/integration/README.md
@@ -76,3 +76,12 @@ pytest tests/integration -q
 
 ## Status
 Experimental – helpers may change as integration needs evolve.
+
+### Changelog
+- Added `assert_request_received` to validate HTTP requests made to the mock server.
+- Enhanced type hints and explicit return types across helper functions.
+- Expanded documentation with a navigation section and additional usage notes.
+
+### Future Considerations
+- Provide asynchronous variants of the helpers for `httpx.AsyncClient`.
+- Offer higher-level fixtures for more complex authentication flows.


### PR DESCRIPTION
## Summary
- append changelog section to integration helper docs
- outline future considerations for async helpers and fixtures

## Testing
- `poetry run pre-commit run --files apiconfig/testing/integration/README.md`
- `poetry run pre-commit run --all-files` *(fails: mypy reports duplicate module named `apiconfig.utils.http`)*


------
https://chatgpt.com/codex/tasks/task_e_684b0aed183c8332ab14cc6ca5b34a15