### PR TITLE
Update unit testing readme navigation

### DIFF
--- a/apiconfig/testing/unit/README.md
+++ b/apiconfig/testing/unit/README.md
@@ -4,6 +4,13 @@ Helpers for writing unit tests against **apiconfig**. The package provides
 assertions, factory functions and mock objects so tests remain concise and free
 of external dependencies.
 
+## Navigation
+
+- **Parent:** [../README.md](../README.md)
+- **Submodules:**
+  - [mocks/README.md](mocks/README.md) – mock implementations for authentication
+    strategies and config providers.
+
 ## Contents
 - `assertions.py` – convenience assertions such as `assert_client_config_valid`.
 - `factories.py` – factory helpers for creating valid or invalid `ClientConfig` instances.


### PR DESCRIPTION
## Summary
- add a navigation section linking back to the parent README and mocks submodule

## Testing
- `poetry run pytest`
- `poetry run pre-commit run --files apiconfig/testing/unit/README.md`


------
https://chatgpt.com/codex/tasks/task_e_684b0ae8d46083329ceb3be2093c86b3