### PR TITLE
Update config README for poetry usage

### DIFF
--- a/apiconfig/config/README.md
+++ b/apiconfig/config/README.md
@@ -50,9 +50,8 @@ flowchart TB
 ## Tests
 Install dependencies and run the unit tests for the configuration package:
 ```bash
-python -m pip install -e .
-python -m pip install pytest
-pytest tests/unit/config -q
+poetry install --with dev
+poetry run pytest tests/unit/config -q
 ```
 
 ## Status


### PR DESCRIPTION
## Summary
- update installation and testing instructions in `config` package docs

## Testing
- `poetry run pre-commit run --files apiconfig/config/README.md`
- `poetry run pytest tests/unit/config -q`


------
https://chatgpt.com/codex/tasks/task_e_684b0ae69478833285ab2fb6c191aab4