### PR TITLE
Update auth README for poetry

### DIFF
--- a/apiconfig/auth/README.md
+++ b/apiconfig/auth/README.md
@@ -50,9 +50,8 @@ sequenceDiagram
 ## Tests
 Install dependencies and run the unit tests for the authentication package:
 ```bash
-python -m pip install -e .
-python -m pip install pytest pytest-xdist
-pytest tests/unit/auth -q
+poetry install --with dev
+poetry run pytest tests/unit/auth -q
 ```
 
 ## Dependencies


### PR DESCRIPTION
## Summary
- update install/test instructions to use Poetry

## Testing
- `poetry run pre-commit run --files apiconfig/auth/README.md`
- `poetry run pytest tests/unit/auth -q && echo SUCCESS`

------
https://chatgpt.com/codex/tasks/task_e_684b0ae5707c833290456d03147dbb4a