### PR TITLE
Improve utils docs and status block

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,13 +315,9 @@ LGPL-3.0-or-later. See [LICENSE](LICENSE) for details.
 
 ## Status
 
-### Stability
-
-Stable - the project is actively used in production environments.
-
-### API Version
-
-Follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) starting at version 0.x.
+**Stability:** Stable - the project is actively used in production environments.
+**API Version:** Follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) starting at version 0.x.
+**Deprecations:** None.
 
 ### Maintenance Notes
 

--- a/apiconfig/utils/README.md
+++ b/apiconfig/utils/README.md
@@ -1,8 +1,16 @@
 # apiconfig.utils
 
-Miscellaneous utilities shipped with **apiconfig**. They cover HTTP helpers,
-URL construction, redaction of sensitive data and logging setup. Each subpackage
-can be used independently by API clients.
+## Module Description
+
+The utilities package houses small, focused helpers that other
+**apiconfig** modules depend on. It includes HTTP status helpers,
+URL construction functions, logging configuration and tools for
+redacting sensitive information.
+
+These utilities simplify writing API clients by handling common tasks
+like normalising URLs or removing secrets from logs. Each subpackage
+is lightweight and can be used independently of the rest of
+**apiconfig**.
 
 ## Navigation
 


### PR DESCRIPTION
## Summary
- document purpose of the utilities package
- restructure the Status section with API version and deprecation info

## Testing
- `poetry run pre-commit run --files README.md apiconfig/utils/README.md`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1b9f47b48332a645584278cab94e