### PR TITLE
Update Status sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,13 +315,9 @@ LGPL-3.0-or-later. See [LICENSE](LICENSE) for details.
 
 ## Status
 
-### Stability
-
-Stable - the project is actively used in production environments.
-
-### API Version
-
-Follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) starting at version 0.x.
+**Stability:** Stable - the project is actively used in production environments.
+**API Version:** Follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) starting at version 0.x.
+**Deprecations:** None
 
 ### Maintenance Notes
 

--- a/apiconfig/auth/README.md
+++ b/apiconfig/auth/README.md
@@ -71,7 +71,10 @@ poetry run pytest tests/unit/auth -q
 - `httpx` – recommended HTTP client for token refresh callbacks and testing.
 
 ## Status
-Stable – used by the configuration system and tested via the unit suite.
+
+**Stability:** Stable – used by the configuration system and tested via the unit suite.
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ## Navigation
 - [apiconfig](../README.md) – project overview and main documentation.

--- a/apiconfig/auth/strategies/README.md
+++ b/apiconfig/auth/strategies/README.md
@@ -74,4 +74,7 @@ pytest tests/unit/auth/strategies -q
 ```
 
 ## Status
-Stable – the strategies are used by other parts of **apiconfig** and have dedicated test coverage.
+
+**Stability:** Stable – the strategies are used by other parts of **apiconfig** and have dedicated test coverage.
+**API Version:** 0.3.1
+**Deprecations:** None

--- a/apiconfig/auth/token/README.md
+++ b/apiconfig/auth/token/README.md
@@ -85,7 +85,9 @@ pytest tests/unit/auth/token -q
 
 ## Status
 
-The module is considered **stable** and is used by other parts of the library.
+**Stability:** Stable – used by other parts of the library.
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ### Future Considerations
 

--- a/apiconfig/config/README.md
+++ b/apiconfig/config/README.md
@@ -55,7 +55,10 @@ poetry run pytest tests/unit/config -q
 ```
 
 ## Status
-Stable – used by API clients and covered by unit tests.
+
+**Stability:** Stable – used by API clients and covered by unit tests.
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ## Navigation
 - [apiconfig](../README.md)

--- a/apiconfig/config/providers/README.md
+++ b/apiconfig/config/providers/README.md
@@ -59,4 +59,7 @@ pytest tests/unit/config/providers -q
 ```
 
 ## Status
-Stable – used internally by other modules in the package.
+
+**Stability:** Stable – used internally by other modules in the package.
+**API Version:** 0.3.1
+**Deprecations:** None

--- a/apiconfig/exceptions/README.md
+++ b/apiconfig/exceptions/README.md
@@ -81,6 +81,8 @@ pytest tests/unit/exceptions -q
 ```
 
 ## Status
-Stable – exceptions are widely used across the library and covered by unit
-tests.
+
+**Stability:** Stable – exceptions are widely used across the library and covered by unit tests.
+**API Version:** 0.3.1
+**Deprecations:** None
 

--- a/apiconfig/testing/README.md
+++ b/apiconfig/testing/README.md
@@ -52,4 +52,7 @@ pytest -q
 ```
 
 ## Status
-Internal – APIs may evolve alongside the test suite.
+
+**Stability:** Internal – APIs may evolve alongside the test suite.
+**API Version:** 0.3.1
+**Deprecations:** None

--- a/apiconfig/testing/integration/README.md
+++ b/apiconfig/testing/integration/README.md
@@ -75,7 +75,10 @@ pytest tests/integration -q
 ```
 
 ## Status
-Experimental – helpers may change as integration needs evolve.
+
+**Stability:** Experimental – helpers may change as integration needs evolve.
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ### Changelog
 - Added `assert_request_received` to validate HTTP requests made to the mock server.

--- a/apiconfig/testing/unit/README.md
+++ b/apiconfig/testing/unit/README.md
@@ -60,9 +60,9 @@ pytest tests/unit/testing/unit -q
 
 ## Status
 
-- **Stability:** Internal
-- **API Version:** v0.3.1
-- **Deprecations:** None
+**Stability:** Internal
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ### Maintenance Notes
 These helpers evolve in tandem with the unit tests. New utilities are added when

--- a/apiconfig/testing/unit/mocks/README.md
+++ b/apiconfig/testing/unit/mocks/README.md
@@ -62,4 +62,7 @@ pytest tests/unit/testing/unit/mocks -q
 ```
 
 ## Status
-Internal – provided solely for unit testing purposes but kept stable.
+
+**Stability:** Internal – provided solely for unit testing purposes but kept stable.
+**API Version:** 0.3.1
+**Deprecations:** None

--- a/apiconfig/types/README.md
+++ b/apiconfig/types/README.md
@@ -25,7 +25,10 @@ payload: JsonObject = {"ping": "pong"}
 ```
 
 ## Status
-Stable – used throughout the library for type checking.
+
+**Stability:** Stable – used throughout the library for type checking.
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ### Maintenance Notes
 New type aliases are added only when multiple modules need the same

--- a/apiconfig/utils/README.md
+++ b/apiconfig/utils/README.md
@@ -70,4 +70,7 @@ pytest tests/unit/utils -q
 ```
 
 ## Status
-Stable – used throughout the project.
+
+**Stability:** Stable – used throughout the project.
+**API Version:** 0.3.1
+**Deprecations:** None

--- a/apiconfig/utils/logging/README.md
+++ b/apiconfig/utils/logging/README.md
@@ -75,7 +75,10 @@ pytest tests/unit/utils/logging -q
 ```
 
 ## Status
-Stable – provides common logging setup for the library.
+
+**Stability:** Stable – provides common logging setup for the library.
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ## Navigation
 

--- a/apiconfig/utils/logging/formatters/README.md
+++ b/apiconfig/utils/logging/formatters/README.md
@@ -78,7 +78,10 @@ pytest tests/unit/utils/logging/formatters -q
 ```
 
 ## Status
-Stable – widely used by other modules for consistent logging behaviour.
+
+**Stability:** Stable – widely used by other modules for consistent logging behaviour.
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ## Navigation
 

--- a/apiconfig/utils/redaction/README.md
+++ b/apiconfig/utils/redaction/README.md
@@ -51,7 +51,10 @@ pytest --cov=apiconfig --cov-report=html
 ```
 
 ## Status
-Stable – used internally for logging and HTTP utilities.
+
+**Stability:** Stable – used internally for logging and HTTP utilities.
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ### Maintenance Notes
 The module is considered stable and receives updates only for critical bug fixes

--- a/helpers_for_tests/common/README.md
+++ b/helpers_for_tests/common/README.md
@@ -56,4 +56,7 @@ pytest tests/unit/helpers/common -q
 ```
 
 ## Status
-Internal – intended only for the helper clients used in tests.
+
+**Stability:** Internal – intended only for the helper clients used in tests.
+**API Version:** 0.3.1
+**Deprecations:** None

--- a/helpers_for_tests/fiken/README.md
+++ b/helpers_for_tests/fiken/README.md
@@ -35,4 +35,7 @@ FIKEN_timeout=10.0
 ```
 
 ## Status
-Internal – for example tests only.
+
+**Stability:** Internal – for example tests only.
+**API Version:** 0.3.1
+**Deprecations:** None

--- a/helpers_for_tests/oneflow/README.md
+++ b/helpers_for_tests/oneflow/README.md
@@ -36,4 +36,7 @@ ONEFLOW_timeout=10.0
 ```
 
 ## Status
-Internal – for example tests only.
+
+**Stability:** Internal – for example tests only.
+**API Version:** 0.3.1
+**Deprecations:** None

--- a/helpers_for_tests/tripletex/README.md
+++ b/helpers_for_tests/tripletex/README.md
@@ -39,4 +39,7 @@ TRIPLETEX_TEST_timeout=30.0
 ```
 
 ## Status
-Internal – for example tests only.
+
+**Stability:** Internal – for example tests only.
+**API Version:** 0.3.1
+**Deprecations:** None


### PR DESCRIPTION
## Summary
- document API version and deprecations across README files
- keep docs aligned with internal documentation guide

## Testing
- `poetry run pre-commit run --files README.md apiconfig/auth/README.md apiconfig/auth/strategies/README.md apiconfig/auth/token/README.md apiconfig/config/README.md apiconfig/config/providers/README.md apiconfig/exceptions/README.md apiconfig/testing/README.md apiconfig/testing/integration/README.md apiconfig/testing/unit/README.md apiconfig/testing/unit/mocks/README.md apiconfig/types/README.md apiconfig/utils/README.md apiconfig/utils/logging/README.md apiconfig/utils/logging/formatters/README.md apiconfig/utils/redaction/README.md helpers_for_tests/common/README.md helpers_for_tests/fiken/README.md helpers_for_tests/oneflow/README.md helpers_for_tests/tripletex/README.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b1ba022888332bf9f271f74680a30