### PR TITLE
Add See Also links in exceptions README

### DIFF
--- a/apiconfig/exceptions/README.md
+++ b/apiconfig/exceptions/README.md
@@ -80,6 +80,10 @@ python -m pip install pytest
 pytest tests/unit/exceptions -q
 ```
 
+## See Also
+- [auth](../auth/README.md) – strategies that raise authentication errors
+- [config](../config/README.md) – configuration providers that emit errors
+
 ## Status
 Stable – exceptions are widely used across the library and covered by unit
 tests.


### PR DESCRIPTION
## Summary
- document auth and config references in `apiconfig.exceptions`

## Testing
- `poetry run pre-commit run --files apiconfig/exceptions/README.md`


------
https://chatgpt.com/codex/tasks/task_e_684b1b9cf2e08332b98460229be735f9