### PR TITLE
Add maintenance sections to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) starting at v
 
 ### Maintenance Notes
 
-Issues and pull requests are triaged on a best-effort basis. Minor feature requests and fixes are welcome.
+The library is currently **stable** and actively maintained. Issues and pull requests are triaged on a best-effort basis. Minor feature requests and fixes are welcome.
 
 ### Changelog
 
@@ -333,4 +333,4 @@ See [CHANGELOG.md](CHANGELOG.md) for a complete history of changes.
 
 ### Future Considerations
 
-Planned improvements include enhanced documentation, additional auth strategies, and expanded test coverage.
+Planned improvements include enhanced documentation, additional auth strategies, expanded test coverage, and formatter enhancements for more consistent styling.

--- a/apiconfig/auth/README.md
+++ b/apiconfig/auth/README.md
@@ -73,6 +73,15 @@ poetry run pytest tests/unit/auth -q
 ## Status
 Stable – used by the configuration system and tested via the unit suite.
 
+### Maintenance Notes
+- Authentication layer is stable and updated as new schemes are supported.
+
+### Changelog
+- Significant auth changes are captured in the project changelog.
+
+### Future Considerations
+- Upcoming work includes improved OAuth2 token refresh handling.
+
 ## Navigation
 - [apiconfig](../README.md) – project overview and main documentation.
 - [strategies](./strategies/README.md) – built-in authentication strategies.

--- a/apiconfig/auth/strategies/README.md
+++ b/apiconfig/auth/strategies/README.md
@@ -75,3 +75,12 @@ pytest tests/unit/auth/strategies -q
 
 ## Status
 Stable – the strategies are used by other parts of **apiconfig** and have dedicated test coverage.
+
+### Maintenance Notes
+- Strategies are stable with occasional improvements for new authentication flows.
+
+### Changelog
+- Updates are logged in the project changelog.
+
+### Future Considerations
+- Support for additional token exchange mechanisms is planned.

--- a/apiconfig/auth/token/README.md
+++ b/apiconfig/auth/token/README.md
@@ -87,6 +87,12 @@ pytest tests/unit/auth/token -q
 
 The module is considered **stable** and is used by other parts of the library.
 
+### Maintenance Notes
+- Actively maintained with bug fixes and periodic compatibility updates.
+
+### Changelog
+- Token management changes are recorded in the main changelog.
+
 ### Future Considerations
 
 - Support for additional storage backends, such as Redis or SQL databases.

--- a/apiconfig/config/README.md
+++ b/apiconfig/config/README.md
@@ -57,6 +57,15 @@ poetry run pytest tests/unit/config -q
 ## Status
 Stable – used by API clients and covered by unit tests.
 
+### Maintenance Notes
+- Considered stable with occasional updates for new configuration sources.
+
+### Changelog
+- See the project changelog for release notes affecting configuration behavior.
+
+### Future Considerations
+- Potential support for dynamic configuration providers.
+
 ## Navigation
 - [apiconfig](../README.md)
 - [providers](./providers/README.md)

--- a/apiconfig/config/providers/README.md
+++ b/apiconfig/config/providers/README.md
@@ -60,3 +60,12 @@ pytest tests/unit/config/providers -q
 
 ## Status
 Stable – used internally by other modules in the package.
+
+### Maintenance Notes
+- Stable provider API with incremental enhancements as new sources are added.
+
+### Changelog
+- Refer to project changelog for provider additions and fixes.
+
+### Future Considerations
+- Explore pluggable provider registration for custom environments.

--- a/apiconfig/exceptions/README.md
+++ b/apiconfig/exceptions/README.md
@@ -84,3 +84,12 @@ pytest tests/unit/exceptions -q
 Stable – exceptions are widely used across the library and covered by unit
 tests.
 
+### Maintenance Notes
+- Exception hierarchy is stable; new exceptions added as needed.
+
+### Changelog
+- Major changes are noted in the project changelog.
+
+### Future Considerations
+- Possible expansion for async error handling.
+

--- a/apiconfig/testing/README.md
+++ b/apiconfig/testing/README.md
@@ -53,3 +53,12 @@ pytest -q
 
 ## Status
 Internal – APIs may evolve alongside the test suite.
+
+### Maintenance Notes
+- Test utilities are maintained with the suite and may change frequently.
+
+### Changelog
+- No separate changelog; refer to repository history for changes.
+
+### Future Considerations
+- Additional helpers will be introduced as new features require.

--- a/apiconfig/testing/integration/README.md
+++ b/apiconfig/testing/integration/README.md
@@ -77,6 +77,9 @@ pytest tests/integration -q
 ## Status
 Experimental – helpers may change as integration needs evolve.
 
+### Maintenance Notes
+- APIs are experimental and may break between minor releases.
+
 ### Changelog
 - Added `assert_request_received` to validate HTTP requests made to the mock server.
 - Enhanced type hints and explicit return types across helper functions.

--- a/apiconfig/testing/unit/README.md
+++ b/apiconfig/testing/unit/README.md
@@ -69,6 +69,9 @@ These helpers evolve in tandem with the unit tests. New utilities are added when
 test coverage requires them while keeping backwards compatibility whenever
 possible.
 
+### Changelog
+- Test helper updates are captured in the main changelog.
+
 ### Future Considerations
 - Extend mocks for additional authentication strategies
 - Add async-aware helpers to cover upcoming async clients

--- a/apiconfig/testing/unit/mocks/README.md
+++ b/apiconfig/testing/unit/mocks/README.md
@@ -63,3 +63,12 @@ pytest tests/unit/testing/unit/mocks -q
 
 ## Status
 Internal – provided solely for unit testing purposes but kept stable.
+
+### Maintenance Notes
+- Maintained alongside the unit tests; expect changes when mocks require new features.
+
+### Changelog
+- Mock updates are documented in the main changelog.
+
+### Future Considerations
+- Additional mocks may be added as the test suite expands.

--- a/apiconfig/types/README.md
+++ b/apiconfig/types/README.md
@@ -32,3 +32,9 @@ New type aliases are added only when multiple modules need the same
 structure. Every addition is documented in the changelog and covered by unit
 tests. Deprecated aliases are marked and removed during the next major
 release cycle.
+
+### Changelog
+- Type alias changes are tracked in the project changelog.
+
+### Future Considerations
+- Additional generic types may be introduced as new modules appear.

--- a/apiconfig/utils/README.md
+++ b/apiconfig/utils/README.md
@@ -71,3 +71,12 @@ pytest tests/unit/utils -q
 
 ## Status
 Stable – used throughout the project.
+
+### Maintenance Notes
+- Stable utilities with occasional updates for new helper functions.
+
+### Changelog
+- See project changelog for utility updates and bug fixes.
+
+### Future Considerations
+- Add async-friendly helpers and improve formatter integration.

--- a/apiconfig/utils/logging/README.md
+++ b/apiconfig/utils/logging/README.md
@@ -77,6 +77,15 @@ pytest tests/unit/utils/logging -q
 ## Status
 Stable – provides common logging setup for the library.
 
+### Maintenance Notes
+- Logging utilities are stable; maintenance focuses on bug fixes and minor improvements.
+
+### Changelog
+- Refer to the project changelog for logging-related updates.
+
+### Future Considerations
+- Planned formatter enhancements will improve log readability.
+
 ## Navigation
 
 **Parent Module:** [apiconfig.utils](../README.md)

--- a/apiconfig/utils/logging/formatters/README.md
+++ b/apiconfig/utils/logging/formatters/README.md
@@ -80,6 +80,15 @@ pytest tests/unit/utils/logging/formatters -q
 ## Status
 Stable – widely used by other modules for consistent logging behaviour.
 
+### Maintenance Notes
+- Considered stable; only critical bug fixes are expected.
+
+### Changelog
+- Changes are tracked in the project changelog.
+
+### Future Considerations
+- Additional formatter presets are planned for upcoming releases.
+
 ## Navigation
 
 **Parent Package:** [apiconfig.utils.logging](../README.md)

--- a/apiconfig/utils/redaction/README.md
+++ b/apiconfig/utils/redaction/README.md
@@ -57,6 +57,9 @@ Stable – used internally for logging and HTTP utilities.
 The module is considered stable and receives updates only for critical bug fixes
 or security patches. No major changes are currently planned.
 
+### Changelog
+- Redaction utilities follow the main project changelog.
+
 ### Future Considerations
 Possible enhancements include more granular redaction options and performance
 optimisations for handling very large payloads.

--- a/helpers_for_tests/common/README.md
+++ b/helpers_for_tests/common/README.md
@@ -57,3 +57,12 @@ pytest tests/unit/helpers/common -q
 
 ## Status
 Internal – intended only for the helper clients used in tests.
+
+### Maintenance Notes
+- APIs may change to support evolving test requirements.
+
+### Changelog
+- No dedicated changelog. See repository history for details.
+
+### Future Considerations
+- Updates will track new testing patterns as needed.

--- a/helpers_for_tests/fiken/README.md
+++ b/helpers_for_tests/fiken/README.md
@@ -36,3 +36,12 @@ FIKEN_timeout=10.0
 
 ## Status
 Internal – for example tests only.
+
+### Maintenance Notes
+- Used solely for testing; interfaces may change.
+
+### Changelog
+- No dedicated changelog. See project history for updates.
+
+### Future Considerations
+- Adjust as the Fiken API evolves.

--- a/helpers_for_tests/oneflow/README.md
+++ b/helpers_for_tests/oneflow/README.md
@@ -37,3 +37,12 @@ ONEFLOW_timeout=10.0
 
 ## Status
 Internal – for example tests only.
+
+### Maintenance Notes
+- Provided for integration tests and may change without notice.
+
+### Changelog
+- No dedicated changelog. Refer to repository history.
+
+### Future Considerations
+- Update along with underlying Oneflow API changes.

--- a/helpers_for_tests/tripletex/README.md
+++ b/helpers_for_tests/tripletex/README.md
@@ -40,3 +40,12 @@ TRIPLETEX_TEST_timeout=30.0
 
 ## Status
 Internal – for example tests only.
+
+### Maintenance Notes
+- This helper module is stable enough for the project tests but may change without notice.
+
+### Changelog
+- No dedicated changelog. Refer to the main repository history for updates.
+
+### Future Considerations
+- No major updates planned beyond keeping tests functional.


### PR DESCRIPTION
## Summary
- extend README status section with stability notes and formatter plans
- add 'Maintenance Notes', 'Changelog' and 'Future Considerations' sections to module READMEs

## Testing
- `pre-commit run --files README.md apiconfig/auth/README.md apiconfig/auth/strategies/README.md apiconfig/auth/token/README.md apiconfig/config/README.md apiconfig/config/providers/README.md apiconfig/exceptions/README.md apiconfig/testing/README.md apiconfig/testing/integration/README.md apiconfig/testing/unit/README.md apiconfig/testing/unit/mocks/README.md apiconfig/types/README.md apiconfig/utils/README.md apiconfig/utils/logging/README.md apiconfig/utils/logging/formatters/README.md apiconfig/utils/redaction/README.md helpers_for_tests/common/README.md helpers_for_tests/fiken/README.md helpers_for_tests/oneflow/README.md helpers_for_tests/tripletex/README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1b9d8e8483328d3fe75c5d751960