### PR TITLE
Update README Status sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,13 +315,9 @@ LGPL-3.0-or-later. See [LICENSE](LICENSE) for details.
 
 ## Status
 
-### Stability
-
-Stable - the project is actively used in production environments.
-
-### API Version
-
-Follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) starting at version 0.x.
+**Stability:** Stable - the project is actively used in production environments.
+**API Version:** Follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) starting at version 0.x.
+**Deprecations:** None
 
 ### Maintenance Notes
 

--- a/apiconfig/README.md
+++ b/apiconfig/README.md
@@ -74,6 +74,7 @@ pytest -q
 ```
 
 ## Status
+
 **Stability:** Stable
 **API Version:** 0.0.0
 **Deprecations:** None

--- a/apiconfig/auth/token/README.md
+++ b/apiconfig/auth/token/README.md
@@ -85,7 +85,9 @@ pytest tests/unit/auth/token -q
 
 ## Status
 
-The module is considered **stable** and is used by other parts of the library.
+**Stability:** Stable
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ### Future Considerations
 

--- a/apiconfig/testing/integration/README.md
+++ b/apiconfig/testing/integration/README.md
@@ -75,7 +75,10 @@ pytest tests/integration -q
 ```
 
 ## Status
-Experimental – helpers may change as integration needs evolve.
+
+**Stability:** Experimental
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ### Changelog
 - Added `assert_request_received` to validate HTTP requests made to the mock server.

--- a/apiconfig/testing/unit/README.md
+++ b/apiconfig/testing/unit/README.md
@@ -60,9 +60,9 @@ pytest tests/unit/testing/unit -q
 
 ## Status
 
-- **Stability:** Internal
-- **API Version:** v0.3.1
-- **Deprecations:** None
+**Stability:** Internal
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ### Maintenance Notes
 These helpers evolve in tandem with the unit tests. New utilities are added when

--- a/apiconfig/utils/redaction/README.md
+++ b/apiconfig/utils/redaction/README.md
@@ -51,7 +51,10 @@ pytest --cov=apiconfig --cov-report=html
 ```
 
 ## Status
-Stable – used internally for logging and HTTP utilities.
+
+**Stability:** Stable
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ### Maintenance Notes
 The module is considered stable and receives updates only for critical bug fixes


### PR DESCRIPTION
## Summary
- streamline "Status" sections to use a common field format
- clarify auth token, integration helper, unit helper and redaction docs

## Testing
- `poetry run pre-commit run --files README.md apiconfig/README.md apiconfig/auth/token/README.md apiconfig/testing/integration/README.md apiconfig/testing/unit/README.md apiconfig/utils/redaction/README.md`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1b9c5fdc8332b353a022e1cbac9f