### PR TITLE
Fix integration README intro placement

### DIFF
--- a/apiconfig/testing/integration/README.md
+++ b/apiconfig/testing/integration/README.md
@@ -1,12 +1,12 @@
 # apiconfig.testing.integration
 
+Utilities for end-to-end tests of **apiconfig** based clients. The package contains helpers for spinning up mock HTTP servers and convenient pytest fixtures so integrations can be validated without hitting real services.
+
 ## Navigation
 
 **Parent:** [../README.md](../README.md)
 
 Submodules: none.
-
-Utilities for end-to-end tests of **apiconfig** based clients. The package contains helpers for spinning up mock HTTP servers and convenient pytest fixtures so integrations can be validated without hitting real services.
 
 ## Contents
 - `fixtures.py` – pytest fixtures that provide temporary config files, HTTP server addresses and ready-made `ConfigManager` instances.


### PR DESCRIPTION
## Summary
- reorganize docs in `apiconfig.testing.integration` README so the intro paragraph follows the header

## Testing
- `poetry run pre-commit run --files apiconfig/testing/integration/README.md`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4b658a9c8332a775cc7e16965939