### PR TITLE
docs: update navigation in types README

### DIFF
--- a/apiconfig/types/README.md
+++ b/apiconfig/types/README.md
@@ -10,7 +10,7 @@ contracts when exchanging data. This reduces duplication and helps type
 checkers catch integration errors early.
 
 ## Navigation
-- [Project README](../README.md)
+**Parent Module:** [apiconfig](../README.md)
 
 ## Contents
 - `types.py`


### PR DESCRIPTION
## Summary
- tweak navigation link in the `apiconfig.types` docs

## Testing
- `poetry run pre-commit run --files apiconfig/types/README.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b4b66c4dc8332ae33dcdba8a7efaa