### PR TITLE
Add See Also section to auth README

### DIFF
--- a/apiconfig/auth/README.md
+++ b/apiconfig/auth/README.md
@@ -86,3 +86,7 @@ Stable – used by the configuration system and tested via the unit suite.
 - [apiconfig](../README.md) – project overview and main documentation.
 - [strategies](./strategies/README.md) – built-in authentication strategies.
 - [token](./token/README.md) – utilities for managing OAuth2 tokens.
+
+## See Also
+- [apiconfig.config](../config/README.md) – configuration system used with auth strategies
+- [apiconfig.exceptions.auth](../exceptions/auth/README.md) – exceptions raised during authentication


### PR DESCRIPTION
## Summary
- document related modules in `auth` README

## Testing
- `poetry run pre-commit run --files apiconfig/auth/README.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b4b67c53483329ecfc11f03fa266a