### PR TITLE
Add See Also links in token README

### DIFF
--- a/apiconfig/auth/token/README.md
+++ b/apiconfig/auth/token/README.md
@@ -100,3 +100,8 @@ pytest tests/unit/auth/token -q
 - Support for additional storage backends, such as Redis or SQL databases.
 - CLI utilities to manage tokens outside of application code.
 - Enhanced logging and error reporting during token refresh.
+
+## See Also
+
+- [apiconfig.exceptions.auth](../../exceptions/auth/README.md) – errors raised during token refresh
+- [apiconfig.utils.logging](../../utils/logging/README.md) – logging helpers for refresh operations


### PR DESCRIPTION
## Summary
- link auth exceptions and logging docs at the end of token README

## Testing
- `poetry run pytest`
- `poetry run pre-commit run --files apiconfig/auth/token/README.md`


------
https://chatgpt.com/codex/tasks/task_e_684b4b69072c8332ab9b018fd97824a5