### PR TITLE
docs: add see also links in strategies readme

### DIFF
--- a/apiconfig/auth/strategies/README.md
+++ b/apiconfig/auth/strategies/README.md
@@ -84,3 +84,7 @@ Stable – the strategies are used by other parts of **apiconfig** and have dedi
 
 ### Future Considerations
 - Support for additional token exchange mechanisms is planned.
+
+## See Also
+- [apiconfig.auth.token](../token/README.md) – token refresh utilities
+- [apiconfig.exceptions.auth](../../exceptions/auth/README.md) – related authentication errors


### PR DESCRIPTION
## Summary
- document related modules for auth strategies

## Testing
- `poetry run pre-commit run --files apiconfig/auth/strategies/README.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b4b6b032883328fe520bc7c96ce5b