### PR TITLE
Add dependencies section to provider docs

### DIFF
--- a/apiconfig/config/providers/README.md
+++ b/apiconfig/config/providers/README.md
@@ -58,6 +58,14 @@ python -m pip install pytest
 pytest tests/unit/config/providers -q
 ```
 
+## Dependencies
+This package uses a mix of Python's standard library and internal modules:
+
+- `json` – file parsing for `FileProvider`.
+- `os` – environment access for `EnvProvider`.
+- `ConfigManager` – orchestrates provider loading.
+- `apiconfig.exceptions` – base exceptions for error handling.
+
 ## Status
 Stable – used internally by other modules in the package.
 


### PR DESCRIPTION
## Summary
- document provider dependencies in README

## Testing
- `poetry run pre-commit run --files apiconfig/config/providers/README.md`
- `poetry run pytest tests/unit/`

------
https://chatgpt.com/codex/tasks/task_e_684c2cf51cd083328d244bb0173dc292