### PR TITLE
Add module description to logging README

### DIFF
--- a/apiconfig/utils/logging/README.md
+++ b/apiconfig/utils/logging/README.md
@@ -4,6 +4,16 @@ Logging helpers used across **apiconfig**. This package bundles custom
 formatters, context filters and convenience functions for setting up redacted
 logging output.
 
+## Module Description
+
+The logging utilities build on the redaction helpers to provide safe and
+context-rich output. Custom formatters such as `RedactingFormatter` apply the
+redaction functions to scrub sensitive values before emitting a log message.
+Handlers like `ConsoleHandler` make these formatters easy to wire up while
+staying compatible with the standard `logging` handlers. Thread-local context
+filters add request or user metadata to log records so that each entry carries
+useful debugging information.
+
 ## Contents
 - `filters.py` – thread-local `ContextFilter` and helper functions for log context.
 - `handlers.py` – `ConsoleHandler` and `RedactingStreamHandler` wrappers around `logging.StreamHandler`.


### PR DESCRIPTION
## Summary
- document how the logging utilities build on redaction

## Testing
- `pre-commit run --files apiconfig/utils/logging/README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c2cf15a3083328c366f45ffab3d1e