### PR TITLE
Add module description to auth README

### DIFF
--- a/apiconfig/auth/README.md
+++ b/apiconfig/auth/README.md
@@ -2,6 +2,20 @@
 
 Authentication framework for **apiconfig**.  This package defines the common `AuthStrategy` base class and bundles the built in authentication strategies and token utilities.
 
+## Module Description
+
+`AuthStrategy` defines the interface used by all authentication implementations.
+The package includes ready-made strategies such as `BasicAuth`, `BearerAuth`,
+and `ApiKeyAuth` so clients can authenticate without custom code.
+
+Centralizing authentication ensures headers and query parameters are prepared
+consistently across APIs. Each `ClientConfig` instance holds a strategy, keeping
+request logic independent of specific credentials or token refresh flows.
+
+This design follows the Strategy pattern and encourages extensibility.
+Applications can swap built-in strategies or provide custom implementations
+without modifying consumers of `ClientConfig`.
+
 ## Contents
 - `base.py` – abstract `AuthStrategy` with refresh support.
 - `strategies/` – collection of ready to use strategies such as `BasicAuth`, `BearerAuth` and `ApiKeyAuth`.


### PR DESCRIPTION
## Summary
- document how AuthStrategy works and why auth is centralized

## Testing
- `poetry run pre-commit run --files apiconfig/auth/README.md`

------
https://chatgpt.com/codex/tasks/task_e_684c2cee6174833291592c71fa167d66