### PR TITLE
Add dependencies docs

### DIFF
--- a/apiconfig/README.md
+++ b/apiconfig/README.md
@@ -75,6 +75,15 @@ python -m pip install pytest pytest-httpserver pytest-xdist
 pytest -q
 ```
 
+## Dependencies
+
+### Standard Library
+- `typing` – used for type hints across the project.
+- `http` – provides HTTP status utilities for the examples.
+
+### Internal Modules
+- `apiconfig.utils.http` – shared helpers for constructing URLs and requests.
+
 ## Status
 
 **Stability:** Stable

--- a/apiconfig/exceptions/README.md
+++ b/apiconfig/exceptions/README.md
@@ -97,6 +97,15 @@ python -m pip install pytest
 pytest tests/unit/exceptions -q
 ```
 
+## Dependencies
+
+### Standard Library
+- `typing` – used for type annotations in the exceptions.
+- `http` – provides HTTP status codes for certain errors.
+
+### Internal Modules
+- `apiconfig.utils.http` – helpers used when raising client errors.
+
 ## See Also
 - [auth](../auth/README.md) – strategies that raise authentication errors
 - [config](../config/README.md) – configuration providers that emit errors

--- a/apiconfig/testing/integration/README.md
+++ b/apiconfig/testing/integration/README.md
@@ -74,6 +74,15 @@ python -m pip install pytest pytest-httpserver
 pytest tests/integration -q
 ```
 
+## Dependencies
+
+### Standard Library
+- `typing` – provides type hints for the integration helpers.
+- `http` – for HTTP status utilities in the examples.
+
+### Internal Modules
+- `apiconfig.utils.http` – URL and request helpers reused in tests.
+
 ## Status
 
 **Stability:** Experimental

--- a/apiconfig/utils/redaction/README.md
+++ b/apiconfig/utils/redaction/README.md
@@ -60,6 +60,15 @@ Run unit tests with coverage:
 pytest --cov=apiconfig --cov-report=html
 ```
 
+## Dependencies
+
+### Standard Library
+- `typing` – common type hints for function signatures.
+- `http` – HTTP utilities referenced in examples.
+
+### Internal Modules
+- `apiconfig.utils.http` – helpers used to build request representations.
+
 ## Status
 
 **Stability:** Stable


### PR DESCRIPTION
## Summary
- document dependencies after Testing sections

## Testing
- `pre-commit run --files apiconfig/README.md apiconfig/exceptions/README.md apiconfig/testing/integration/README.md apiconfig/utils/redaction/README.md`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_684c49015ab0833295b37c6a76eb17aa