### PR TITLE
Fix logging docs order

### DIFF
--- a/apiconfig/auth/README.md
+++ b/apiconfig/auth/README.md
@@ -16,6 +16,11 @@ This design follows the Strategy pattern and encourages extensibility.
 Applications can swap built-in strategies or provide custom implementations
 without modifying consumers of `ClientConfig`.
 
+## Navigation
+- [apiconfig](../README.md) – project overview and main documentation.
+- [strategies](./strategies/README.md) – built-in authentication strategies.
+- [token](./token/README.md) – utilities for managing OAuth2 tokens.
+
 ## Contents
 - `base.py` – abstract `AuthStrategy` with refresh support.
 - `strategies/` – collection of ready to use strategies such as `BasicAuth`, `BearerAuth` and `ApiKeyAuth`.
@@ -95,11 +100,6 @@ Stable – used by the configuration system and tested via the unit suite.
 
 ### Future Considerations
 - Upcoming work includes improved OAuth2 token refresh handling.
-
-## Navigation
-- [apiconfig](../README.md) – project overview and main documentation.
-- [strategies](./strategies/README.md) – built-in authentication strategies.
-- [token](./token/README.md) – utilities for managing OAuth2 tokens.
 
 ## See Also
 - [apiconfig.config](../config/README.md) – configuration system used with auth strategies

--- a/apiconfig/config/README.md
+++ b/apiconfig/config/README.md
@@ -22,6 +22,10 @@ Core configuration system for **apiconfig**.  This module exposes the `ClientCon
 class used by API clients and the `ConfigManager` which coordinates loading of
 configuration values from one or more providers.
 
+## Navigation
+- [apiconfig](../README.md)
+- [providers](./providers/README.md)
+
 ## Contents
 - `base.py` – `ClientConfig` with helpers for merging settings and constructing `base_url`.
 - `manager.py` – `ConfigManager` that merges dictionaries from multiple providers.
@@ -83,10 +87,6 @@ Stable – used by API clients and covered by unit tests.
 
 ### Future Considerations
 - Potential support for dynamic configuration providers.
-
-## Navigation
-- [apiconfig](../README.md)
-- [providers](./providers/README.md)
 
 ## See Also
 - [auth](../auth/README.md) - describes available authentication strategies used by `ClientConfig`.

--- a/apiconfig/utils/logging/README.md
+++ b/apiconfig/utils/logging/README.md
@@ -14,6 +14,21 @@ staying compatible with the standard `logging` handlers. Thread-local context
 filters add request or user metadata to log records so that each entry carries
 useful debugging information.
 
+## Navigation
+
+**Parent Module:** [apiconfig.utils](../README.md)
+
+**Submodules:**
+- [formatters](./formatters/README.md) - Custom log formatters
+
+## Dependencies
+
+### Standard Library
+- `logging` – Python logging framework used by handlers and formatters
+
+### Internal Dependencies
+- `apiconfig.utils.redaction` – redaction helpers for sanitising log output
+
 ## Contents
 - `filters.py` – thread-local `ContextFilter` and helper functions for log context.
 - `handlers.py` – `ConsoleHandler` and `RedactingStreamHandler` wrappers around `logging.StreamHandler`.
@@ -95,13 +110,6 @@ Stable – provides common logging setup for the library.
 
 ### Future Considerations
 - Planned formatter enhancements will improve log readability.
-
-## Navigation
-
-**Parent Module:** [apiconfig.utils](../README.md)
-
-**Submodules:**
-- [formatters](./formatters/README.md) - Custom log formatters
 
 ## See Also
 - [apiconfig.utils.redaction](../redaction/README.md) – used by log formatters

--- a/apiconfig/utils/logging/formatters/README.md
+++ b/apiconfig/utils/logging/formatters/README.md
@@ -19,6 +19,11 @@ delegate sensitive-data handling to the utilities in
 match formatters and redaction strategies without rewriting their logging
 setup.
 
+## Navigation
+
+**Parent Package:** [apiconfig.utils.logging](../README.md)
+
+
 ## Contents
 - `detailed.py` – `DetailedFormatter` adds timestamps, level names, logger names
   and file/line information with smart handling of multiline messages and stack
@@ -88,8 +93,4 @@ Stable – widely used by other modules for consistent logging behaviour.
 
 ### Future Considerations
 - Additional formatter presets are planned for upcoming releases.
-
-## Navigation
-
-**Parent Package:** [apiconfig.utils.logging](../README.md)
 


### PR DESCRIPTION
## Summary
- move `## Navigation` up so it comes right after module description
- document dependencies for the logging utilities
- align navigation sections in auth, config and formatter docs

## Testing
- `poetry run pre-commit run --files apiconfig/auth/README.md apiconfig/config/README.md apiconfig/utils/logging/README.md apiconfig/utils/logging/formatters/README.md`

------
https://chatgpt.com/codex/tasks/task_e_684c49023310833293e03c983eecac62