### PR TITLE
docs: clarify logging deps

### DIFF
--- a/apiconfig/utils/logging/README.md
+++ b/apiconfig/utils/logging/README.md
@@ -76,6 +76,14 @@ flowchart TD
     Formatter -->|redact| Redaction
 ```
 
+## Dependencies
+
+### Standard Library
+- `logging` – built on Python's logging framework for handlers and configuration.
+
+### Internal Dependencies
+- `apiconfig.utils.redaction` – utilities for scrubbing sensitive data from log messages.
+
 ## Tests
 Run the logging-related unit tests:
 ```bash


### PR DESCRIPTION
## Summary
- add Dependencies section to logging docs

## Testing
- `poetry run pre-commit run --files apiconfig/utils/logging/README.md`
- `poetry run pytest tests/unit/`

------
https://chatgpt.com/codex/tasks/task_e_684c4901c05883328f1300c69912b90e