### PR TITLE
Update example docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,15 @@ Continuous integration and deployment are managed with GitHub Actions. All pushe
 
 LGPL-3.0-or-later. See [LICENSE](LICENSE) for details.
 
+## Dependencies
+
+The project relies on `pytest` and `pytest_httpserver` for its test suite. Install development
+dependencies with:
+
+```bash
+poetry install --with dev
+```
+
 ## Status
 
 **Stability:** Stable - the project is actively used in production environments.

--- a/apiconfig/testing/README.md
+++ b/apiconfig/testing/README.md
@@ -36,13 +36,23 @@ simple to contribute to and easier to maintain.
 - `auth_verification.py` – common checks for authentication headers during tests.
 - `__init__.py` – exposes the most useful helpers across subpackages.
 
-## Example
+## Usage Examples
+
+### Basic
 ```python
 from apiconfig.testing.integration import configure_mock_response
 from apiconfig.testing.unit import create_valid_client_config
 
 config = create_valid_client_config(hostname="api.test")
 configure_mock_response(httpserver, path="/ping", response_data={"ok": True})
+```
+
+### Advanced
+```python
+from apiconfig.testing.integration import assert_request_received
+
+# After configuring responses and making requests, verify the server interaction
+assert_request_received(httpserver, path="/ping")
 ```
 
 ## Key modules
@@ -67,6 +77,15 @@ Install dependencies and run all project tests:
 python -m pip install -e .
 python -m pip install pytest pytest-httpserver pytest-xdist
 pytest -q
+```
+
+## Dependencies
+
+Testing relies on `pytest` and `pytest_httpserver`. Install them via the project
+development dependencies:
+
+```bash
+poetry install --with dev
 ```
 
 ## Status

--- a/apiconfig/testing/unit/README.md
+++ b/apiconfig/testing/unit/README.md
@@ -18,7 +18,9 @@ of external dependencies.
 - `mocks/` – lightweight mock implementations of auth strategies and config providers.
 - `__init__.py` – re-exports the most common helpers.
 
-## Example
+## Usage Examples
+
+### Basic
 ```python
 from apiconfig.testing.unit import (
     create_valid_client_config,
@@ -30,6 +32,14 @@ provider = MockConfigProvider({"hostname": "api.test"})
 manager = MockConfigManager([provider])
 config = manager.load_config()
 assert config.hostname == "api.test"
+```
+
+### Advanced
+```python
+from apiconfig.testing.unit import create_invalid_client_config
+
+# Use factories to build intentionally invalid configs for edge cases
+config = create_invalid_client_config()
 ```
 
 ## Key helpers
@@ -60,6 +70,15 @@ pytest tests/unit/testing/unit -q
 
 ## See Also
 - [integration](../integration/README.md) – end-to-end helpers.
+
+## Dependencies
+
+Unit tests depend on `pytest` for execution. Install all development
+dependencies with:
+
+```bash
+poetry install --with dev
+```
 
 ## Status
 

--- a/apiconfig/utils/README.md
+++ b/apiconfig/utils/README.md
@@ -28,13 +28,23 @@ to avoid duplicating boilerplate code.
 - `logging/` – custom formatters and setup helpers for the library's logging.
 - `__init__.py` – exposes the modules above for convenience.
 
-## Example
+## Usage Examples
+
+### Basic
 ```python
 from apiconfig.utils import http, url
 
 if http.is_success(200):
     full_url = url.build_url("https://api.example.com", "/ping")
     print(full_url)
+```
+
+### Advanced
+```python
+from apiconfig.utils.redaction import redact_dict
+
+data = {"token": "secret", "value": 42}
+print(redact_dict(data, {"token"}))
 ```
 
 ## Key modules

--- a/apiconfig/utils/logging/README.md
+++ b/apiconfig/utils/logging/README.md
@@ -21,7 +21,9 @@ useful debugging information.
 - `setup.py` – `setup_logging` function to configure the library's logger.
 - `__init__.py` – exports the common classes and helpers.
 
-## Example
+## Usage Examples
+
+### Basic
 ```python
 import logging
 from apiconfig.utils.logging import setup_logging
@@ -31,7 +33,7 @@ logger = logging.getLogger("apiconfig")
 logger.info("configured")
 ```
 
-### Advanced Usage
+### Advanced
 Use the building blocks directly when you need full control over handlers and
 formatters.
 
@@ -82,6 +84,15 @@ Run the logging-related unit tests:
 python -m pip install -e .
 python -m pip install pytest pytest-xdist
 pytest tests/unit/utils/logging -q
+```
+
+## Dependencies
+
+Logging utilities are tested with `pytest` and rely on `pytest_httpserver` for
+mock servers. Install them along with all development requirements:
+
+```bash
+poetry install --with dev
 ```
 
 ## Status


### PR DESCRIPTION
## Summary
- rename Example sections to Usage Examples
- add new Basic and Advanced subsections
- describe pytest dependencies before Status sections

## Testing
- `pre-commit run --files README.md apiconfig/testing/README.md apiconfig/testing/unit/README.md apiconfig/utils/README.md apiconfig/utils/logging/README.md`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c490278948332a05f82c42483fc90