### PR TITLE
Update README dependencies sections

### DIFF
--- a/apiconfig/auth/README.md
+++ b/apiconfig/auth/README.md
@@ -78,17 +78,10 @@ sequenceDiagram
     Client->>Server: HTTP request with headers
 ```
 
-## Tests
-Install dependencies and run the unit tests for the authentication package:
-```bash
-poetry install --with dev
-poetry run pytest tests/unit/auth -q
-```
-
 ## Dependencies
 
-### Standard Library
-- `abc` – defines the abstract base class for auth strategies.
+### External Dependencies
+- `abc` – abstract base classes for auth strategies.
 - `base64` – encodes Basic authentication credentials.
 - `datetime` – handles token expiry timestamps.
 - `json`, `logging`, and `time` – used in token refresh helpers.
@@ -100,6 +93,13 @@ poetry run pytest tests/unit/auth -q
 
 ### Optional Dependencies
 - `httpx` – recommended HTTP client for token refresh callbacks and testing.
+
+## Tests
+Install dependencies and run the unit tests for the authentication package:
+```bash
+poetry install --with dev
+poetry run pytest tests/unit/auth -q
+```
 
 ## Status
 Stable – used by the configuration system and tested via the unit suite.

--- a/apiconfig/testing/README.md
+++ b/apiconfig/testing/README.md
@@ -64,12 +64,23 @@ assert_request_received(httpserver, path="/ping")
 
 ### Diagram
 ```mermaid
-flowchart TD
-    subgraph Testing
-        U[unit] -- mocks --> T[tests]
-        I[integration] -- fixtures --> T
-    end
+    flowchart TD
+        subgraph Testing
+            U[unit] -- mocks --> T[tests]
+            I[integration] -- fixtures --> T
+        end
 ```
+
+## Dependencies
+
+### External Dependencies
+- `pytest`, `pytest_httpserver`, and `pytest-xdist` for running the test suite.
+
+### Internal Dependencies
+- `apiconfig.testing.unit` and `apiconfig.testing.integration` utilities.
+
+### Optional Dependencies
+None
 
 ## Running tests
 Install dependencies and run all project tests:
@@ -79,14 +90,6 @@ python -m pip install pytest pytest-httpserver pytest-xdist
 pytest -q
 ```
 
-## Dependencies
-
-Testing relies on `pytest` and `pytest_httpserver`. Install them via the project
-development dependencies:
-
-```bash
-poetry install --with dev
-```
 
 ## Status
 Internal – APIs may evolve alongside the test suite.

--- a/apiconfig/testing/integration/README.md
+++ b/apiconfig/testing/integration/README.md
@@ -14,10 +14,6 @@ Submodules: none.
 - `servers.py` – utilities to configure and verify responses of `pytest_httpserver`.
 - `__init__.py` – exports the public helpers mentioned above.
 
-## Dependencies
-- `pytest` – required to run the integration tests.
-- Internal mocks from [`apiconfig.testing.unit.mocks`](../unit/mocks/README.md) – used in various examples.
-
 ## Usage
 ```python
 from apiconfig.testing.integration import (
@@ -80,12 +76,16 @@ pytest tests/integration -q
 
 ## Dependencies
 
-### Standard Library
-- `typing` – provides type hints for the integration helpers.
-- `http` – for HTTP status utilities in the examples.
+### External Dependencies
+- `pytest` – required to run the integration tests.
+- `typing` and `http` – standard library modules used in examples.
 
-### Internal Modules
+### Internal Dependencies
 - `apiconfig.utils.http` – URL and request helpers reused in tests.
+- Internal mocks from [`apiconfig.testing.unit.mocks`](../unit/mocks/README.md) – used in various examples.
+
+### Optional Dependencies
+None
 
 ## Status
 

--- a/apiconfig/utils/logging/formatters/README.md
+++ b/apiconfig/utils/logging/formatters/README.md
@@ -74,6 +74,17 @@ sequenceDiagram
     Formatter-->>Logger: formatted string
 ```
 
+## Dependencies
+
+### External Dependencies
+- `logging` – built-in logging package for creating formatters.
+
+### Internal Dependencies
+- `apiconfig.utils.redaction` – redaction utilities used by `RedactingFormatter`.
+
+### Optional Dependencies
+None
+
 ## Tests
 Install dependencies and run the formatter tests:
 ```bash


### PR DESCRIPTION
## Summary
- add dependencies section to logging formatters docs
- move dependencies section closer to diagram in auth docs
- clarify dependencies in testing docs
- consolidate integration testing dependencies

## Testing
- `poetry run pre-commit run --files apiconfig/auth/README.md apiconfig/testing/README.md apiconfig/testing/integration/README.md apiconfig/utils/logging/formatters/README.md`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5ab1b044833287edebed256b0f75