### PR TITLE
Update unit testing README

### DIFF
--- a/apiconfig/testing/unit/README.md
+++ b/apiconfig/testing/unit/README.md
@@ -4,6 +4,10 @@ Helpers for writing unit tests against **apiconfig**. The package provides
 assertions, factory functions and mock objects so tests remain concise and free
 of external dependencies.
 
+## Module Description
+These helpers isolate unit tests from network calls and other side effects.
+They provide mocks, factories and assertions for validating configuration logic.
+
 ## Navigation
 
 - **Parent:** [../README.md](../README.md)
@@ -63,9 +67,8 @@ flowchart TD
 ## Running tests
 Install dependencies and execute the unit tests for this package:
 ```bash
-python -m pip install -e .
-python -m pip install pytest pytest-xdist
-pytest tests/unit/testing/unit -q
+poetry install --with dev
+poetry run pytest tests/unit/testing/unit -q
 ```
 
 ## See Also


### PR DESCRIPTION
## Summary
- add module description for unit test helpers
- switch to poetry-based commands in unit README

## Testing
- `poetry run pre-commit run --files apiconfig/testing/unit/README.md`
- `poetry run pytest tests/unit/testing/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_684c637880fc8332a61c10e2d3b0d93a