### PR TITLE
docs: update testing instructions

### DIFF
--- a/apiconfig/auth/token/README.md
+++ b/apiconfig/auth/token/README.md
@@ -86,9 +86,8 @@ sequenceDiagram
 Install the packages and run the unit tests for this module:
 
 ```bash
-python -m pip install -e .
-python -m pip install pytest pytest-xdist
-pytest tests/unit/auth/token -q
+poetry install --with dev
+poetry run pytest tests/unit/auth/token -q
 ```
 
 ## Status


### PR DESCRIPTION
## Summary
- use poetry install and pytest commands in auth token README

## Testing
- `poetry run pre-commit run --files apiconfig/auth/token/README.md`
- `poetry run pytest tests/unit/auth/token -q`


------
https://chatgpt.com/codex/tasks/task_e_684c6d4792a08332b7731c4028bacd5f