### PR TITLE
Update logging README status info

### DIFF
--- a/apiconfig/utils/logging/README.md
+++ b/apiconfig/utils/logging/README.md
@@ -106,7 +106,9 @@ poetry run pytest tests/unit/utils/logging -q
 
 
 ## Status
-Stable – provides common logging setup for the library.
+**Stability:** Stable
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ### Maintenance Notes
 - Logging utilities are stable; maintenance focuses on bug fixes and minor improvements.


### PR DESCRIPTION
## Summary
- document stability, version and deprecations for `utils.logging`

## Testing
- `poetry run pre-commit run --files apiconfig/utils/logging/README.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c6d465a00833280e5ad675ba846cb