### PR TITLE
Update provider README status section

### DIFF
--- a/apiconfig/config/providers/README.md
+++ b/apiconfig/config/providers/README.md
@@ -66,7 +66,10 @@ This package uses a mix of Python's standard library and internal modules:
 - `apiconfig.exceptions` – base exceptions for error handling.
 
 ## Status
-Stable – used internally by other modules in the package.
+
+**Stability:** Stable
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ### Maintenance Notes
 - Stable provider API with incremental enhancements as new sources are added.


### PR DESCRIPTION
## Summary
- document provider stability in the Status section

## Testing
- `poetry run pre-commit run --files apiconfig/config/providers/README.md`

------
https://chatgpt.com/codex/tasks/task_e_684c6d44b89c8332b8b4bf8c2a88ca17