### PR TITLE
Update auth status documentation

### DIFF
--- a/apiconfig/auth/README.md
+++ b/apiconfig/auth/README.md
@@ -102,7 +102,10 @@ poetry run pytest tests/unit/auth -q
 ```
 
 ## Status
-Stable – used by the configuration system and tested via the unit suite.
+
+**Stability:** Stable – used by the configuration system and tested via the unit suite.
+**API Version:** 0.3.1
+**Deprecations:** None
 
 ### Maintenance Notes
 - Authentication layer is stable and updated as new schemes are supported.


### PR DESCRIPTION
## Summary
- expand the Status section in the auth documentation

## Testing
- `pre-commit run --files apiconfig/auth/README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c6d43b4cc83329dfda2de97323768