### PR TITLE
Add status bullets in types README

### DIFF
--- a/apiconfig/types/README.md
+++ b/apiconfig/types/README.md
@@ -47,6 +47,10 @@ poetry run pytest tests/unit/types
 ## Status
 Stable – used throughout the library for type checking.
 
+**Stability:** Stable
+**API Version:** 0.3.2
+**Deprecations:** None
+
 ### Maintenance Notes
 New type aliases are added only when multiple modules need the same
 structure. Every addition is documented in the changelog and covered by unit


### PR DESCRIPTION
## Summary
- clarify stability, version and deprecation info for the `types` module

## Testing
- `pre-commit run --files apiconfig/types/README.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c7565d528833280a231964e9d78ed