### PR TITLE
Update utils README tests instructions

### DIFF
--- a/apiconfig/utils/README.md
+++ b/apiconfig/utils/README.md
@@ -82,9 +82,8 @@ flowchart TD
 ## Tests
 Run the unit tests for utility modules:
 ```bash
-python -m pip install -e .
-python -m pip install pytest pytest-xdist
-pytest tests/unit/utils -q
+poetry install --with dev
+poetry run pytest tests/unit/utils -q
 ```
 
 ## Status


### PR DESCRIPTION
## Summary
- switch to Poetry install for utils README tests section

## Testing
- `poetry run pre-commit run --files apiconfig/utils/README.md`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c755f8aac8332b37cad90812de4c0