### PR TITLE
Update Tripletex helper docs

### DIFF
--- a/helpers_for_tests/tripletex/README.md
+++ b/helpers_for_tests/tripletex/README.md
@@ -41,6 +41,10 @@ TRIPLETEX_TEST_timeout=30.0
 ## Status
 Internal – for example tests only.
 
+**Stability:** Stable for internal testing
+**API Version:** v2
+**Deprecations:** None
+
 ### Maintenance Notes
 - This helper module is stable enough for the project tests but may change without notice.
 
@@ -49,3 +53,12 @@ Internal – for example tests only.
 
 ### Future Considerations
 - No major updates planned beyond keeping tests functional.
+
+## Tests
+```bash
+poetry install --with dev
+poetry run pytest tests/integration/test_apiconfig_tripletex.py tests/integration/test_tripletex_auth_refresh.py
+```
+
+## Navigation
+- [helpers_for_tests](../README.md)


### PR DESCRIPTION
## Summary
- document navigation link from the Tripletex helper guide
- add stability, version, and deprecation bullets under **Status**
- describe commands for running Tripletex integration tests

## Testing
- `pre-commit run --files helpers_for_tests/tripletex/README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c755e73288332a4fcfaf4dcdc580d