### PR TITLE
Update oneflow helper README

### DIFF
--- a/helpers_for_tests/oneflow/README.md
+++ b/helpers_for_tests/oneflow/README.md
@@ -2,6 +2,9 @@
 
 Utilities for testing integrations with the OneFlow API.
 
+## Navigation
+- [Back to `helpers_for_tests`](../README.md)
+
 ## Contents
 - `oneflow_client.py` – `OneFlowClient` with simple user and contract endpoints
 - `oneflow_config.py` – configuration helpers (`create_oneflow_client_config`, etc.)
@@ -35,8 +38,16 @@ ONEFLOW_version=v1
 ONEFLOW_timeout=10.0
 ```
 
+## Tests
+```bash
+poetry run pytest tests/integration/test_apiconfig_oneflow.py -q
+```
+
 ## Status
-Internal – for example tests only.
+
+- **Stability:** Internal – for example tests only.
+- **API Version:** Matches sample endpoints used in tests.
+- **Deprecations:** None.
 
 ### Maintenance Notes
 - Provided for integration tests and may change without notice.


### PR DESCRIPTION
## Summary
- add navigation link back to main helpers readme
- list stability, API version and deprecations in Status section
- include example integration test command

## Testing
- `poetry run pre-commit run --files helpers_for_tests/oneflow/README.md`
- `poetry run pytest tests/integration/test_apiconfig_oneflow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684c755dcf3c8332a83fac6c3fec0c93