### PR TITLE
Update helper client documentation

### DIFF
--- a/helpers_for_tests/README.md
+++ b/helpers_for_tests/README.md
@@ -1,11 +1,36 @@
 # helpers_for_tests
 
-Example clients used in the test suite. Each submodule contains a minimal API client and configuration helpers built on top of **apiconfig**.
+## Module Description
+This directory provides thin example clients used in the test suite. Each package offers minimal wrappers around **apiconfig** to simplify integration scenarios.
 
-## Available clients
+## Navigation
 - [common](common/README.md) – shared `BaseClient` utilities
 - [fiken](fiken/README.md) – Fiken API helpers
 - [oneflow](oneflow/README.md) – OneFlow API helpers
 - [tripletex](tripletex/README.md) – Tripletex API helpers
 
-These modules are for internal testing only. See each README for usage examples and required environment variables.
+## Contents
+- `README.md` – this guide
+- `__init__.py` – package marker
+- `common/` – shared base client utilities
+- `fiken/` – Fiken helpers
+- `oneflow/` – OneFlow helpers
+- `tripletex/` – Tripletex helpers
+
+## Usage example
+```python
+from helpers_for_tests.fiken import create_fiken_client_config, FikenClient
+
+config = create_fiken_client_config()
+client = FikenClient(config)
+companies = client.list_companies()
+```
+
+## Status
+- **Stability**: Internal-only helpers
+- **API Version**: Mirrors project defaults
+- **Deprecations**: None
+- **Maintenance**: Updated as tests evolve
+
+### Future Considerations
+- Expand examples with new API patterns as needed.


### PR DESCRIPTION
## Summary
- extend documentation for `helpers_for_tests`

## Testing
- `pre-commit run --files helpers_for_tests/README.md`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c755bbfd0833292ab9ff00709cb17