### PR TITLE
Update test instructions in redaction README

### DIFF
--- a/apiconfig/utils/redaction/README.md
+++ b/apiconfig/utils/redaction/README.md
@@ -57,7 +57,8 @@ flowchart TD
 ## Testing
 Run unit tests with coverage:
 ```bash
-pytest --cov=apiconfig --cov-report=html
+poetry install --with dev
+poetry run pytest --cov=apiconfig --cov-report=html
 ```
 
 ## Dependencies


### PR DESCRIPTION
## Summary
- update example test commands for redaction docs

## Testing
- `poetry run pre-commit run --files apiconfig/utils/redaction/README.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c756172308332b3c972218a3b4b72