### PR TITLE
Add parent module link for test helpers

### DIFF
--- a/helpers_for_tests/README.md
+++ b/helpers_for_tests/README.md
@@ -4,6 +4,7 @@
 This directory provides thin example clients used in the test suite. Each package offers minimal wrappers around **apiconfig** to simplify integration scenarios.
 
 ## Navigation
+**Parent Module:** [apiconfig.testing](../apiconfig/testing/README.md)
 - [common](common/README.md) – shared `BaseClient` utilities
 - [fiken](fiken/README.md) – Fiken API helpers
 - [oneflow](oneflow/README.md) – OneFlow API helpers


### PR DESCRIPTION
## Summary
- document parent module in helpers_for_tests README

## Testing
- `poetry run pre-commit run --files helpers_for_tests/README.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684e0b1532048332ab002ec9bb19cf32