### PR TITLE
Update test instructions in README

### DIFF
--- a/apiconfig/auth/strategies/README.md
+++ b/apiconfig/auth/strategies/README.md
@@ -71,9 +71,8 @@ sequenceDiagram
 ## Test instructions
 Install dependencies and run the unit tests for this module:
 ```bash
-python -m pip install -e .
-python -m pip install pytest
-pytest tests/unit/auth/strategies -q
+poetry install --with dev
+poetry run pytest tests/unit/auth/strategies -q
 ```
 
 ## Status


### PR DESCRIPTION
## Summary
- clarify test instructions for auth strategies README

## Testing
- `poetry run pytest tests/unit/auth/strategies -q`
- `pre-commit run --files apiconfig/auth/strategies/README.md`


------
https://chatgpt.com/codex/tasks/task_e_684e0b0f436c83329e6e3912ec69d4f0