### PR TITLE
Add See Also links

### DIFF
--- a/apiconfig/README.md
+++ b/apiconfig/README.md
@@ -97,3 +97,8 @@ poetry run pytest -q
 
 ### Future Considerations
 - Expand documentation for custom provider integrations.
+
+## See Also
+
+- [helpers_for_tests](../helpers_for_tests/README.md) – example clients used in the test suite
+- [project_plans](../project_plans/README.md) – design documents and task lists for upcoming features


### PR DESCRIPTION
## Summary
- add cross-references to helpers_for_tests and project_plans in the package README

## Testing
- `poetry run pre-commit run --files apiconfig/README.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684e0b0f14e08332b68e841d0c68c809