### PR TITLE
Update providers README

### DIFF
--- a/apiconfig/config/providers/README.md
+++ b/apiconfig/config/providers/README.md
@@ -32,22 +32,23 @@ print(config["timeout"])
 ```
 
 ## Key Classes
-| Class | Description |
-| ----- | ----------- |
-| `EnvProvider` | Loads variables with a prefix (default `APICONFIG_`) and coerces simple types when possible. |
-| `FileProvider` | Reads JSON files and allows retrieval of values with dot notation and type conversion. |
-| `MemoryProvider` | Stores configuration in an internal dictionary. |
+| Class | Description | Key Methods |
+| ----- | ----------- | ----------- |
+| `EnvProvider` | Loads variables with a prefix (default `APICONFIG_`) and coerces simple types when possible. | `load()`, `get()` |
+| `FileProvider` | Reads JSON files and allows retrieval of values with dot notation and type conversion. | `load()`, `get()` |
+| `MemoryProvider` | Stores configuration in an internal dictionary. | `get_config()` |
 
 ### Design
 Providers follow a simple strategy-like pattern: each exposes a `load()` method returning
 a dictionary which `ConfigManager` merges in order. Later providers override earlier ones.
 
+## Architecture
 ```mermaid
 flowchart TB
-    A[EnvProvider] --> M(ConfigManager)
-    B[FileProvider] --> M
-    C[MemoryProvider] --> M
-    M --> D[Config dict]
+    EnvProvider --> ConfigManager
+    FileProvider --> ConfigManager
+    MemoryProvider --> ConfigManager
+    ConfigManager --> ConfigDict[Config dict]
 ```
 
 ## Testing


### PR DESCRIPTION
## Summary
- document provider API methods
- illustrate provider architecture

## Testing
- `poetry run pytest -q`
- `poetry run pre-commit run --files apiconfig/config/providers/README.md`

------
https://chatgpt.com/codex/tasks/task_e_68505a08dea88332a351c44073480109