### PR TITLE
Update utils README

### DIFF
--- a/apiconfig/utils/README.md
+++ b/apiconfig/utils/README.md
@@ -47,18 +47,19 @@ data = {"token": "secret", "value": 42}
 print(redact_dict(data, {"token"}))
 ```
 
-## Key modules
-| Module | Purpose |
-| ------ | ------- |
-| `http` | HTTP status helpers and safe JSON encode/decode with custom exceptions. |
-| `url` | Build URLs and normalise query parameters with type safety. |
-| `redaction` | Remove sensitive data before logging or output. |
-| `logging` | Formatters, handlers and setup utilities for clean log output. |
+## Key Components
+| Module | Purpose | Key Functions |
+| ------ | ------- | ------------- |
+| `http` | HTTP status helpers and safe JSON encode/decode with custom exceptions. | `is_success`, `safe_json_decode`, `safe_json_encode` |
+| `url` | Build URLs and normalise query parameters with type safety. | `build_url`, `add_query_params` |
+| `redaction` | Remove sensitive data before logging or output. | `redact_body`, `redact_headers` |
+| `logging` | Formatters, handlers and setup utilities for clean log output. | `setup_logging`, `set_log_context` |
 
 ### Design
 Utility modules are kept lightweight and independent. Logging utilities compose
 the redaction helpers to avoid code duplication.
 
+## Architecture
 ```mermaid
 flowchart TD
     Redaction --> Logging


### PR DESCRIPTION
## Summary
- rename "Key modules" to "Key Components"
- add a new column for key functions
- introduce an Architecture section with a Mermaid diagram

## Testing
- `poetry run pre-commit run --files apiconfig/utils/README.md`
- `poetry run pre-commit run --hook-stage pre-push --files apiconfig/utils/README.md`


------
https://chatgpt.com/codex/tasks/task_e_68505a04b6b08332bbf468ef4ed65e7b