### PR TITLE
test: remove redundant import

### DIFF
--- a/tests/unit/config/test_manager.py
+++ b/tests/unit/config/test_manager.py
@@ -185,8 +185,6 @@ class TestConfigManager:
 
     def test_load_config_provider_returns_non_dict_value_warning(self, caplog: LogCaptureFixture) -> None:
         """Test loading config from a provider that returns a non-dict value logs a warning."""
-        import logging
-
         caplog.set_level(logging.WARNING)
 
         # Create a provider that returns a non-dict value


### PR DESCRIPTION
## Summary
- remove unneeded `logging` import in `test_load_config_provider_returns_non_dict_value_warning`
- rely on module-level `logging` import

## Testing
- `poetry run pre-commit run --files tests/unit/config/test_manager.py`
- `poetry run pytest tests/unit/config/test_manager.py::test_load_config_provider_returns_non_dict_value_warning -q`

------
https://chatgpt.com/codex/tasks/task_e_68699cac1b9c83328d7f3bf046b89326