### PR TITLE
Update redaction test imports

### DIFF
--- a/tests/unit/utils/redaction/test_headers.py
+++ b/tests/unit/utils/redaction/test_headers.py
@@ -1,5 +1,11 @@
-import re
-from typing import Dict, Optional, Pattern, Set, Tuple
+import re  # pyright: ignore[reportShadowedImports]
+from typing import (  # pyright: ignore[reportShadowedImports]
+    Dict,
+    Optional,
+    Pattern,
+    Set,
+    Tuple,
+)
 
 import pytest
 


### PR DESCRIPTION
## Summary
- silence pyright shadowed-import warnings in redaction tests

## Testing
- `pre-commit run --files tests/unit/utils/redaction/test_headers.py`


------
https://chatgpt.com/codex/tasks/task_e_68699c9737b883329bb791b1dd9f75d6