### PR TITLE
Add pyright ignore comment in test

### DIFF
--- a/tests/unit/utils/redaction/test_body.py
+++ b/tests/unit/utils/redaction/test_body.py
@@ -1,6 +1,11 @@
 import json
 import re
-from typing import Any, Optional, Pattern, Union
+from typing import (  # pyright: ignore[reportShadowedImports]
+    Any,
+    Optional,
+    Pattern,
+    Union,
+)
 
 import pytest
 


### PR DESCRIPTION
## Summary
- silence Pyright shadowed import warnings in tests

## Testing
- `poetry run pytest tests/unit/utils/redaction/test_body.py -q`
- `poetry run pre-commit run --files tests/unit/utils/redaction/test_body.py`

------
https://chatgpt.com/codex/tasks/task_e_68699c9658cc833284d0528890009ff3