### PR TITLE
Update test_filters.py for pyright ignore comment

### DIFF
--- a/tests/unit/utils/logging/test_filters.py
+++ b/tests/unit/utils/logging/test_filters.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Generator
+from typing import Any, Generator  # pyright: ignore[reportShadowedImports]
 
 import pytest
 


### PR DESCRIPTION
## Summary
- silence pyright shadowed import warnings in logging filter tests

## Testing
- `pre-commit run --files tests/unit/utils/logging/test_filters.py`

------
https://chatgpt.com/codex/tasks/task_e_68699c9508948332bfdc39df17357697