### PR TITLE
Amend typing import line for pyright

### DIFF
--- a/tests/unit/utils/logging/formatters/test_redacting.py
+++ b/tests/unit/utils/logging/formatters/test_redacting.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, cast
+from typing import Any, Callable, cast  # pyright: ignore[reportShadowedImports]
 
 import pytest
 


### PR DESCRIPTION
## Summary
- add pyright ignore directive to typing import in `test_redacting.py`

## Testing
- `poetry run pytest tests/unit/utils/logging/formatters/test_redacting.py -q`
- `poetry run pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68699c94482c833281376755f7b0e51f