### PR TITLE
Fix JWT verification test imports

### DIFF
--- a/tests/component/test_phase2_cross_component_integration.py
+++ b/tests/component/test_phase2_cross_component_integration.py
@@ -81,10 +81,10 @@ class TestPhase2CrossComponentIntegration:
         header = {"typ": "JWT", "alg": "HS256"}
         payload = {"sub": "1234567890", "name": "Test User", "exp": 1234567890}
 
-        import json
+        import json as json_lib
 
-        header_b64 = base64.b64encode(json.dumps(header).encode()).decode().rstrip("=")
-        payload_b64 = base64.b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+        header_b64 = base64.b64encode(json_lib.dumps(header).encode()).decode().rstrip("=")
+        payload_b64 = base64.b64encode(json_lib.dumps(payload).encode()).decode().rstrip("=")
         signature_b64 = "mock_signature"
 
         jwt_token = f"{header_b64}.{payload_b64}.{signature_b64}"


### PR DESCRIPTION
## Summary
- avoid `json` import shadowing by importing json as `json_lib`
- update usage in `test_advanced_verification_with_mock_jwt`

## Testing
- `poetry run pre-commit run --files tests/component/test_phase2_cross_component_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68699c8559688332a1ca1cd8c3e3df4f