### PR TITLE
Fix BaseAuthStrategyTest strategy annotation

### DIFF
--- a/apiconfig/testing/unit/helpers.py
+++ b/apiconfig/testing/unit/helpers.py
@@ -175,7 +175,7 @@ class BaseAuthStrategyTest(unittest.TestCase):
     strategy they want to test.
     """
 
-    strategy: AuthStrategy
+    strategy: ClassVar[AuthStrategy]
 
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
## Summary
- annotate `BaseAuthStrategyTest.strategy` as `ClassVar[AuthStrategy]`

## Testing
- `poetry run pre-commit run --files apiconfig/testing/unit/helpers.py`
- `poetry run pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_68699c67c7b0833288c15c04f45b515b