### PR TITLE
Add typed context attributes to mixin

### DIFF
--- a/apiconfig/exceptions/base.py
+++ b/apiconfig/exceptions/base.py
@@ -23,6 +23,13 @@ class ConfigurationError(APIConfigError):
 class HttpContextMixin:
     """Mixin to add HTTP context extraction capabilities to exceptions."""
 
+    status_code: Optional[int] = None
+    method: Optional[str] = None
+    url: Optional[str] = None
+    reason: Optional[str] = None
+    request: Optional[HttpRequestProtocol] = None
+    response: Optional[HttpResponseProtocol] = None
+
     def _init_http_context(
         self, request: Optional[HttpRequestProtocol] = None, response: Optional[HttpResponseProtocol] = None, status_code: Optional[int] = None
     ) -> None:


### PR DESCRIPTION
## Summary
- add typed class attributes in `HttpContextMixin`

## Testing
- `poetry run pre-commit run --files apiconfig/exceptions/base.py`
- `poetry run pytest tests/unit/exceptions`


------
https://chatgpt.com/codex/tasks/task_e_68699c6734348332882404d0faab2c6f