### PR TITLE
Refactor tests to use api_types alias

### DIFF
--- a/docs/source/auth_refresh_guide.rst
+++ b/docs/source/auth_refresh_guide.rst
@@ -72,7 +72,7 @@ Custom Auth Strategy with Refresh
 .. code-block:: python
 
     from apiconfig.auth.base import AuthStrategy
-    from apiconfig.types import TokenRefreshResult, RefreshedTokenData
+    import apiconfig.types as api_types
 
     class CustomSessionAuth(AuthStrategy):
         def __init__(self, session_token, refresh_endpoint, http_request_callable=None):

--- a/project_plans/finished/crudclient_integration_implementation/tasks/phase1_component_validation.md
+++ b/project_plans/finished/crudclient_integration_implementation/tasks/phase1_component_validation.md
@@ -22,7 +22,7 @@ import pytest
 from unittest.mock import Mock, patch
 from apiconfig.auth.strategies.bearer import BearerAuth
 from apiconfig.auth.strategies.custom import CustomAuth
-from apiconfig.types import TokenRefreshResult
+import apiconfig.types as api_types
 
 class TestAuthRefreshInterface:
     """Test refresh interface consistency across auth strategies."""

--- a/project_plans/finished/crudclient_integration_implementation/tasks/phase3_task5_documentation_examples.md
+++ b/project_plans/finished/crudclient_integration_implementation/tasks/phase3_task5_documentation_examples.md
@@ -138,7 +138,7 @@ Custom Auth Strategy with Refresh
 .. code-block:: python
 
     from apiconfig.auth.base import AuthStrategy
-    from apiconfig.types import TokenRefreshResult, RefreshedTokenData
+    import apiconfig.types as api_types
 
     class CustomSessionAuth(AuthStrategy):
         def __init__(self, session_token, refresh_endpoint, http_request_callable=None):

--- a/tests/component/test_auth_refresh_interface.py
+++ b/tests/component/test_auth_refresh_interface.py
@@ -2,9 +2,9 @@
 
 from unittest.mock import Mock
 
+import apiconfig.types as api_types
 from apiconfig.auth.strategies.bearer import BearerAuth
 from apiconfig.auth.strategies.custom import CustomAuth
-from apiconfig.types import TokenRefreshResult
 
 
 class TestAuthRefreshInterface:
@@ -18,7 +18,7 @@ class TestAuthRefreshInterface:
 
         # Create a test subclass of BearerAuth that implements refresh
         class TestBearerAuth(BearerAuth):
-            def refresh(self) -> TokenRefreshResult:
+            def refresh(self) -> api_types.TokenRefreshResult:
                 return {"token_data": {"access_token": "new_token"}, "config_updates": None}
 
         strategies = [
@@ -57,7 +57,7 @@ class TestAuthRefreshInterface:
 
         # Create a test subclass that implements refresh
         class TestBearerAuth(BearerAuth):
-            def refresh(self) -> TokenRefreshResult:
+            def refresh(self) -> api_types.TokenRefreshResult:
                 # old_token = self.access_token  # Unused variable
                 self.access_token = "new_token"
                 return {"token_data": {"access_token": "new_token"}, "config_updates": None}

--- a/tests/component/test_end_to_end_refresh.py
+++ b/tests/component/test_end_to_end_refresh.py
@@ -3,9 +3,9 @@
 from typing import Dict, Optional
 from unittest.mock import Mock, patch
 
+import apiconfig.types as api_types
 from apiconfig.auth.strategies.bearer import BearerAuth
 from apiconfig.auth.strategies.custom import CustomAuth
-from apiconfig.types import TokenRefreshResult
 
 
 class TestEndToEndRefresh:
@@ -37,7 +37,7 @@ class TestEndToEndRefresh:
                 self.token_url = token_url
                 self.client_id = client_id
 
-            def refresh(self) -> TokenRefreshResult:
+            def refresh(self) -> api_types.TokenRefreshResult:
                 # Simulate calling the refresh utility
                 result = mock_refresh()
                 self.access_token = result["access_token"]
@@ -90,7 +90,7 @@ class TestEndToEndRefresh:
         def header_callback() -> Dict[str, str]:
             return {"Authorization": f"Bearer {current_token['value']}"}
 
-        def refresh_func() -> TokenRefreshResult:
+        def refresh_func() -> api_types.TokenRefreshResult:
             current_token["value"] = "new_token"
             return {"token_data": {"access_token": "new_token"}, "config_updates": None}
 

--- a/tests/component/test_enhanced_auth_mocks_refresh.py
+++ b/tests/component/test_enhanced_auth_mocks_refresh.py
@@ -6,6 +6,7 @@ from typing import Dict
 
 import pytest
 
+import apiconfig.types as api_types
 from apiconfig.exceptions.auth import TokenRefreshError
 from apiconfig.testing.unit.mocks.auth import (
     AuthTestScenarioBuilder,
@@ -16,7 +17,6 @@ from apiconfig.testing.unit.mocks.auth import (
     MockHttpRequestCallable,
     MockRefreshableAuthStrategy,
 )
-from apiconfig.types import TokenRefreshResult
 
 
 class TestEnhancedAuthMocksRefresh:
@@ -199,7 +199,7 @@ class TestEnhancedAuthMocksRefresh:
         assert hasattr(strategy, "_refresh_lock")
 
         # Test concurrent refresh operations
-        results: list[TokenRefreshResult] = []
+        results: list[api_types.TokenRefreshResult] = []
         errors: list[Exception] = []
 
         def refresh_worker() -> None:

--- a/tests/component/test_existing_component_integration.py
+++ b/tests/component/test_existing_component_integration.py
@@ -5,10 +5,10 @@ from io import StringIO
 from typing import Any, Dict
 from unittest.mock import Mock
 
+import apiconfig.types as api_types
 from apiconfig.auth.strategies.bearer import BearerAuth
 from apiconfig.auth.strategies.custom import CustomAuth
 from apiconfig.auth.token.storage import InMemoryTokenStorage
-from apiconfig.types import TokenRefreshResult
 
 
 class TestExistingComponentIntegration:
@@ -37,7 +37,7 @@ class TestExistingComponentIntegration:
                 self.refresh_token: str = "default_refresh"
                 self.expires_at: str = "default_expires"
 
-            def refresh(self) -> TokenRefreshResult:
+            def refresh(self) -> api_types.TokenRefreshResult:
                 # Simulate refresh
                 self.access_token = "new_token"
                 self.refresh_token = "new_refresh"
@@ -82,7 +82,7 @@ class TestExistingComponentIntegration:
 
             # Create a test subclass that logs during refresh
             class TestBearerAuth(BearerAuth):
-                def refresh(self) -> TokenRefreshResult:
+                def refresh(self) -> api_types.TokenRefreshResult:
                     logger.info("Bearer token refresh started")
                     self.access_token = "new_token"
                     logger.info("Bearer token refresh successful")
@@ -113,7 +113,7 @@ class TestExistingComponentIntegration:
         def header_callback() -> Dict[str, str]:
             return {"X-API-Key": current_token["value"]}
 
-        def refresh_func() -> TokenRefreshResult:
+        def refresh_func() -> api_types.TokenRefreshResult:
             # Simulate refresh
             new_key = "refreshed_api_key"
             current_token["value"] = new_key

--- a/tests/component/test_phase2_error_scenarios.py
+++ b/tests/component/test_phase2_error_scenarios.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 
 import pytest
 
+import apiconfig.types as api_types
 from apiconfig.exceptions.auth import AuthenticationError, TokenRefreshError
 from apiconfig.testing.auth_verification import (
     AdvancedAuthVerification,
@@ -19,7 +20,6 @@ from apiconfig.testing.unit.mocks.auth import (
     MockHttpRequestCallable,
     MockRefreshableAuthStrategy,
 )
-from apiconfig.types import TokenRefreshResult
 
 
 class TestPhase2ErrorScenarios:
@@ -336,7 +336,7 @@ class TestPhase2ErrorScenarios:
         concurrent_fail_strategy = MockAuthErrorInjector.create_failing_refresh_strategy(failure_type="auth", failure_after_attempts=1)
 
         errors: list[Exception] = []
-        successes: list[TokenRefreshResult | None] = []
+        successes: list[api_types.TokenRefreshResult | None] = []
 
         def concurrent_refresh() -> None:
             try:

--- a/tests/component/test_refresh_error_handling.py
+++ b/tests/component/test_refresh_error_handling.py
@@ -7,10 +7,10 @@ from unittest.mock import Mock
 
 import pytest
 
+import apiconfig.types as api_types
 from apiconfig.auth.strategies.bearer import BearerAuth
 from apiconfig.auth.strategies.custom import CustomAuth
 from apiconfig.exceptions.auth import AuthStrategyError, TokenRefreshError
-from apiconfig.types import TokenRefreshResult
 
 
 class TestRefreshErrorHandling:
@@ -57,7 +57,7 @@ class TestRefreshErrorHandling:
                 super().__init__(*args, **kwargs)
                 self._refresh_lock = threading.Lock()
 
-            def refresh(self) -> TokenRefreshResult:
+            def refresh(self) -> api_types.TokenRefreshResult:
                 with self._refresh_lock:
                     # Simulate some processing time
                     time.sleep(0.01)
@@ -67,7 +67,7 @@ class TestRefreshErrorHandling:
 
         auth = TestBearerAuth(access_token="initial", http_request_callable=mock_http)
 
-        results: list[TokenRefreshResult] = []
+        results: list[api_types.TokenRefreshResult] = []
         errors: list[Exception] = []
 
         def refresh_worker() -> None:

--- a/tests/component/test_refresh_performance.py
+++ b/tests/component/test_refresh_performance.py
@@ -4,9 +4,9 @@ import time
 from typing import Any, Dict
 from unittest.mock import Mock
 
+import apiconfig.types as api_types
 from apiconfig.auth.strategies.bearer import BearerAuth
 from apiconfig.auth.strategies.custom import CustomAuth
-from apiconfig.types import TokenRefreshResult
 
 
 class TestRefreshPerformance:
@@ -19,7 +19,7 @@ class TestRefreshPerformance:
 
         # Create a test subclass that implements refresh
         class TestBearerAuth(BearerAuth):
-            def refresh(self) -> TokenRefreshResult:
+            def refresh(self) -> api_types.TokenRefreshResult:
                 # Simulate minimal refresh logic
                 self.access_token = "new_token"
                 return {"token_data": {"access_token": "new_token"}, "config_updates": None}
@@ -55,7 +55,7 @@ class TestRefreshPerformance:
             call_count += 1
             return {"Authorization": f"Bearer token_{call_count}"}
 
-        def refresh_func() -> TokenRefreshResult:
+        def refresh_func() -> api_types.TokenRefreshResult:
             return {"token_data": {"access_token": f"new_token_{call_count}"}, "config_updates": None}
 
         auth = CustomAuth(header_callback=header_callback, refresh_func=refresh_func, can_refresh_func=lambda: True)
@@ -90,7 +90,7 @@ class TestRefreshPerformance:
                 super().__init__(*args, **kwargs)
                 self.refresh_count = 0
 
-            def refresh(self) -> TokenRefreshResult:
+            def refresh(self) -> api_types.TokenRefreshResult:
                 self.refresh_count += 1
                 self.access_token = f"token_{self.refresh_count}"
                 return {"token_data": {"access_token": self.access_token}, "config_updates": None}
@@ -113,7 +113,7 @@ class TestRefreshPerformance:
 
         # Create a test subclass with fast refresh
         class TestBearerAuth(BearerAuth):
-            def refresh(self) -> TokenRefreshResult:
+            def refresh(self) -> api_types.TokenRefreshResult:
                 self.access_token = "refreshed_token"
                 return {"token_data": {"access_token": "refreshed_token"}, "config_updates": None}
 

--- a/tests/integration/test_tripletex_auth_refresh.py
+++ b/tests/integration/test_tripletex_auth_refresh.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from _pytest.logging import LogCaptureFixture
 
-from apiconfig.types import TokenRefreshResult
+import apiconfig.types as api_types
 
 if os.getenv("PYTEST_SKIP_INTEGRATION", "false").lower() == "true":
     pytest.skip(
@@ -119,7 +119,7 @@ class TestTripletexAuthRefresh:
         countries = tripletex_client.list_countries()
         assert isinstance(countries, dict)
 
-        results: list[TokenRefreshResult | None] = []
+        results: list[api_types.TokenRefreshResult | None] = []
         errors: list[Exception] = []
 
         def refresh_worker() -> None:

--- a/tests/unit/auth/strategies/test_custom.py
+++ b/tests/unit/auth/strategies/test_custom.py
@@ -5,9 +5,9 @@ from unittest.mock import Mock
 
 import pytest
 
+import apiconfig.types as api_types
 from apiconfig.auth.strategies.custom import CustomAuth
 from apiconfig.exceptions.auth import AuthStrategyError
-from apiconfig.types import TokenRefreshResult
 
 
 class TestCustomAuth:
@@ -411,7 +411,7 @@ class TestCustomAuthRefreshIntegration:
             assert isinstance(expires_at, int)
             return current_time >= expires_at
 
-        def refresh_callback() -> Optional[TokenRefreshResult]:
+        def refresh_callback() -> Optional[api_types.TokenRefreshResult]:
             # Simulate getting a new token
             token_state["access_token"] = "refreshed-token"
             current_time = token_state["current_time"]
@@ -458,7 +458,7 @@ class TestCustomAuthRefreshIntegration:
     def test_custom_refresh_error_handling(self) -> None:
         """Test error handling in custom refresh scenarios."""
 
-        def failing_refresh() -> Optional[TokenRefreshResult]:
+        def failing_refresh() -> Optional[api_types.TokenRefreshResult]:
             raise ConnectionError("Network error during refresh")
 
         auth = CustomAuth(

--- a/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
+++ b/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+import apiconfig.types as api_types
 from apiconfig.exceptions.auth import TokenRefreshError
 from apiconfig.testing.unit.mocks.auth import (
     AuthTestScenarioBuilder,
@@ -18,7 +19,6 @@ from apiconfig.testing.unit.mocks.auth import (
     MockHttpRequestCallable,
     MockRefreshableAuthStrategy,
 )
-from apiconfig.types import TokenRefreshResult
 
 
 class TestMockRefreshableAuthStrategy:
@@ -183,7 +183,7 @@ class TestMockRefreshableAuthStrategy:
         """Test refresh callback raises error when refresh returns None."""
 
         class RefreshReturnsNone(MockRefreshableAuthStrategy):
-            def refresh(self) -> Optional[TokenRefreshResult]:
+            def refresh(self) -> Optional[api_types.TokenRefreshResult]:
                 return None
 
         strategy = RefreshReturnsNone()


### PR DESCRIPTION
## Summary
- switch imports from `TokenRefreshResult` to the `api_types` namespace
- update tests and docs to use `api_types.TokenRefreshResult`

## Testing
- `poetry run pre-commit run --files docs/source/auth_refresh_guide.rst project_plans/finished/crudclient_integration_implementation/tasks/phase1_component_validation.md project_plans/finished/crudclient_integration_implementation/tasks/phase3_task5_documentation_examples.md tests/component/test_auth_refresh_interface.py tests/component/test_end_to_end_refresh.py tests/component/test_enhanced_auth_mocks_refresh.py tests/component/test_existing_component_integration.py tests/component/test_phase2_error_scenarios.py tests/component/test_refresh_error_handling.py tests/component/test_refresh_performance.py tests/integration/test_tripletex_auth_refresh.py tests/unit/auth/strategies/test_custom.py tests/unit/testing/mocks/test_enhanced_auth_mocks.py`

------
https://chatgpt.com/codex/tasks/task_e_68699cab1a28833288ab9d55514d71ff