### PR TITLE
Fix variable shadowing in integration tests

### DIFF
--- a/tests/integration/test_httpx_compatibility.py
+++ b/tests/integration/test_httpx_compatibility.py
@@ -11,7 +11,7 @@ from apiconfig.exceptions import (
 from apiconfig.exceptions.auth import ExpiredTokenError
 
 # Only run if httpx is available
-httpx = pytest.importorskip("httpx")
+httpx_lib = pytest.importorskip("httpx")
 
 
 class TestHttpxResponseObjects:
@@ -20,8 +20,8 @@ class TestHttpxResponseObjects:
     def test_with_real_httpx_response(self) -> None:
         """Test with actual httpx.Response object."""
         # Create a mock httpx response
-        request = httpx.Request("GET", "https://api.example.com/data")
-        response = httpx.Response(
+        request = httpx_lib.Request("GET", "https://api.example.com/data")
+        response = httpx_lib.Response(
             status_code=404,
             headers={"content-type": "application/json"},
             content=b'{"error": "Not found"}',
@@ -40,8 +40,8 @@ class TestHttpxResponseObjects:
 
     def test_httpx_sync_client_response(self) -> None:
         """Test with httpx sync client response."""
-        request = httpx.Request("DELETE", "https://api.example.com/resource/123")
-        response = httpx.Response(
+        request = httpx_lib.Request("DELETE", "https://api.example.com/resource/123")
+        response = httpx_lib.Response(
             status_code=403,
             request=request,
             content=b"Forbidden",
@@ -56,8 +56,8 @@ class TestHttpxResponseObjects:
     @pytest.mark.asyncio
     async def test_httpx_async_client_response(self) -> None:
         """Test with httpx async client response."""
-        request = httpx.Request("POST", "https://api.example.com/async/data")
-        response = httpx.Response(
+        request = httpx_lib.Request("POST", "https://api.example.com/async/data")
+        response = httpx_lib.Response(
             status_code=429,
             headers={"Retry-After": "60"},
             request=request,
@@ -75,8 +75,8 @@ class TestHttpxResponseObjects:
 
     def test_httpx_with_json_response(self) -> None:
         """Test with httpx response containing JSON data."""
-        request = httpx.Request("PUT", "https://api.example.com/user/456")
-        response = httpx.Response(
+        request = httpx_lib.Request("PUT", "https://api.example.com/user/456")
+        response = httpx_lib.Response(
             status_code=422,
             headers={"content-type": "application/json"},
             content=b'{"errors": [{"field": "email", "message": "Invalid format"}]}',
@@ -91,8 +91,8 @@ class TestHttpxResponseObjects:
 
     def test_httpx_auth_error(self) -> None:
         """Test authentication error with httpx."""
-        request = httpx.Request("GET", "https://api.example.com/protected", headers={"Authorization": "Bearer expired_token"})
-        response = httpx.Response(
+        request = httpx_lib.Request("GET", "https://api.example.com/protected", headers={"Authorization": "Bearer expired_token"})
+        response = httpx_lib.Response(
             status_code=401,
             headers={"WWW-Authenticate": "Bearer realm='api'"},
             request=request,
@@ -111,10 +111,10 @@ class TestHttpxStreamingResponses:
 
     def test_stream_response(self) -> None:
         """Test with httpx stream response."""
-        request = httpx.Request("GET", "https://api.example.com/stream")
+        request = httpx_lib.Request("GET", "https://api.example.com/stream")
 
         # Create a response with streaming content
-        response = httpx.Response(
+        response = httpx_lib.Response(
             status_code=200,
             request=request,
             # httpx supports various content types
@@ -139,7 +139,7 @@ class TestHttpxEdgeCases:
         handles this specific case gracefully.
         """
         # httpx allows creating responses without requests
-        response = httpx.Response(
+        response = httpx_lib.Response(
             status_code=500,
             content=b"Internal error",
         )
@@ -160,8 +160,8 @@ class TestHttpxEdgeCases:
     def test_httpx_with_custom_transport(self) -> None:
         """Test with httpx response from custom transport."""
         # Simulate a response from a custom transport
-        request = httpx.Request("PATCH", "https://custom.transport/api")
-        response = httpx.Response(
+        request = httpx_lib.Request("PATCH", "https://custom.transport/api")
+        response = httpx_lib.Response(
             status_code=400,
             request=request,
             content=b"Bad request from custom transport",

--- a/tests/integration/test_requests_compatibility.py
+++ b/tests/integration/test_requests_compatibility.py
@@ -11,7 +11,7 @@ from apiconfig.exceptions import (
 from apiconfig.exceptions.auth import AuthenticationError, TokenRefreshError
 
 # Only run if requests is available
-requests = pytest.importorskip("requests")
+requests_lib = pytest.importorskip("requests")
 
 
 class TestRequestsResponseObjects:
@@ -20,11 +20,11 @@ class TestRequestsResponseObjects:
     def test_with_real_requests_response(self) -> None:
         """Test with actual requests.Response object."""
         # Create a mock requests response
-        response = requests.Response()
+        response = requests_lib.Response()
         response.status_code = 400
         response.reason = "Bad Request"
         response.url = "https://api.example.com/test"
-        response.request = requests.Request(method="POST", url=response.url).prepare()
+        response.request = requests_lib.Request(method="POST", url=response.url).prepare()
         response._content = b'{"error": "Invalid data"}'
 
         exc = ApiClientBadRequestError("Request failed", response=response)
@@ -39,15 +39,15 @@ class TestRequestsResponseObjects:
 
     def test_requests_error_chaining(self) -> None:
         """Test exception chaining from requests.HTTPError."""
-        response = requests.Response()
+        response = requests_lib.Response()
         response.status_code = 404
         response.reason = "Not Found"
         response.url = "https://api.example.com/missing"
-        response.request = requests.Request(method="GET", url=response.url).prepare()
+        response.request = requests_lib.Request(method="GET", url=response.url).prepare()
 
         try:
             response.raise_for_status()
-        except requests.HTTPError as e:
+        except requests_lib.HTTPError as e:
             exc = ApiClientNotFoundError("Resource not found", response=e.response)
             assert exc.status_code == 404
             assert exc.method == "GET"
@@ -55,11 +55,11 @@ class TestRequestsResponseObjects:
 
     def test_requests_with_factory_function(self) -> None:
         """Test factory function with requests objects."""
-        response = requests.Response()
+        response = requests_lib.Response()
         response.status_code = 422
         response.reason = "Unprocessable Entity"
         response.url = "https://api.example.com/validate"
-        response.request = requests.Request(method="PUT", url=response.url).prepare()
+        response.request = requests_lib.Request(method="PUT", url=response.url).prepare()
         response._content = b'{"errors": ["field1 is required"]}'
 
         exc = create_api_client_error(422, "Validation failed", response=response)
@@ -72,12 +72,12 @@ class TestRequestsResponseObjects:
     def test_requests_session_response(self) -> None:
         """Test with response from requests.Session."""
         # Create a session and prepare a request
-        session = requests.Session()
-        request = requests.Request(method="DELETE", url="https://api.example.com/item/123", headers={"Authorization": "Bearer token123"})
+        session = requests_lib.Session()
+        request = requests_lib.Request(method="DELETE", url="https://api.example.com/item/123", headers={"Authorization": "Bearer token123"})
         prepared = session.prepare_request(request)
 
         # Create a response
-        response = requests.Response()
+        response = requests_lib.Response()
         response.status_code = 401
         response.reason = "Unauthorized"
         response.url = prepared.url
@@ -93,11 +93,11 @@ class TestRequestsResponseObjects:
 
     def test_requests_with_json_response(self) -> None:
         """Test with requests response containing JSON data."""
-        response = requests.Response()
+        response = requests_lib.Response()
         response.status_code = 400
         response.reason = "Bad Request"
         response.url = "https://api.example.com/data"
-        response.request = requests.Request(method="POST", url=response.url).prepare()
+        response.request = requests_lib.Request(method="POST", url=response.url).prepare()
         response._content = b'{"error": "Invalid input", "code": "VALIDATION_ERROR"}'
         response.headers["Content-Type"] = "application/json"
 
@@ -110,11 +110,11 @@ class TestRequestsResponseObjects:
     def test_requests_token_refresh_scenario(self) -> None:
         """Test token refresh error with requests."""
         # Simulate a token refresh request
-        refresh_request = requests.Request(
+        refresh_request = requests_lib.Request(
             method="POST", url="https://auth.example.com/oauth/token", data={"grant_type": "refresh_token", "refresh_token": "expired_token"}
         ).prepare()
 
-        response = requests.Response()
+        response = requests_lib.Response()
         response.status_code = 400
         response.reason = "Bad Request"
         response.url = refresh_request.url
@@ -133,12 +133,12 @@ class TestRequestsEdgeCases:
 
     def test_response_without_prepared_request(self) -> None:
         """Test response that has unprepared request."""
-        response = requests.Response()
+        response = requests_lib.Response()
         response.status_code = 500
         response.reason = "Internal Server Error"
         response.url = "https://api.example.com/error"
         # Create unprepared request
-        response.request = requests.Request(method="GET", url=response.url)
+        response.request = requests_lib.Request(method="GET", url=response.url)
 
         exc = ApiClientError("Server error", response=response)
 
@@ -150,18 +150,18 @@ class TestRequestsEdgeCases:
     def test_response_with_redirect_history(self) -> None:
         """Test response that went through redirects."""
         # Create the final response
-        response = requests.Response()
+        response = requests_lib.Response()
         response.status_code = 404
         response.reason = "Not Found"
         response.url = "https://api.example.com/final/location"
-        response.request = requests.Request(method="GET", url="https://api.example.com/final/location").prepare()
+        response.request = requests_lib.Request(method="GET", url="https://api.example.com/final/location").prepare()
 
         # Add redirect history
-        redirect1 = requests.Response()
+        redirect1 = requests_lib.Response()
         redirect1.status_code = 301
         redirect1.url = "https://api.example.com/original"
 
-        redirect2 = requests.Response()
+        redirect2 = requests_lib.Response()
         redirect2.status_code = 302
         redirect2.url = "https://api.example.com/intermediate"
 


### PR DESCRIPTION
## Summary
- avoid name shadowing of `httpx` and `requests` modules in integration tests

## Testing
- `pre-commit run --files tests/integration/test_httpx_compatibility.py tests/integration/test_requests_compatibility.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68699cad6a60833295cbf589f5506313