### PR TITLE
Namespace HttpRequestProtocol imports

### DIFF
--- a/apiconfig/exceptions/auth.py
+++ b/apiconfig/exceptions/auth.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 
-from apiconfig.types import HttpRequestProtocol, HttpResponseProtocol
+import apiconfig.types as api_types
 
 from .base import AuthenticationError
 
@@ -26,9 +26,9 @@ class InvalidCredentialsError(AuthenticationError):
     ----------
     message : str
         Error message describing the invalid credentials (default: "Invalid credentials provided")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object (optional)
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object (optional)
     """
 
@@ -36,8 +36,8 @@ class InvalidCredentialsError(AuthenticationError):
         self,
         message: str = "Invalid credentials provided",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, request=request, response=response)
 
@@ -49,9 +49,9 @@ class ExpiredTokenError(AuthenticationError):
     ----------
     message : str
         Error message describing the token expiration (default: "Authentication token has expired")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object (optional)
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object (optional)
     """
 
@@ -59,8 +59,8 @@ class ExpiredTokenError(AuthenticationError):
         self,
         message: str = "Authentication token has expired",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, request=request, response=response)
 
@@ -72,9 +72,9 @@ class MissingCredentialsError(AuthenticationError):
     ----------
     message : str
         Error message describing the missing credentials (default: "Required credentials not provided")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object (optional)
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object (optional)
     """
 
@@ -82,8 +82,8 @@ class MissingCredentialsError(AuthenticationError):
         self,
         message: str = "Required credentials not provided",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, request=request, response=response)
 
@@ -95,9 +95,9 @@ class TokenRefreshError(AuthenticationError):
     ----------
     message : str
         Error message describing the token refresh failure (default: "Failed to refresh authentication token")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object (optional)
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object (optional)
     """
 
@@ -105,8 +105,8 @@ class TokenRefreshError(AuthenticationError):
         self,
         message: str = "Failed to refresh authentication token",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, request=request, response=response)
 
@@ -118,9 +118,9 @@ class TokenRefreshJsonError(TokenRefreshError):
     ----------
     message : str
         Error message describing the JSON decoding failure (default: "Failed to decode JSON from token refresh response")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object (optional)
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object (optional)
     """
 
@@ -128,8 +128,8 @@ class TokenRefreshJsonError(TokenRefreshError):
         self,
         message: str = "Failed to decode JSON from token refresh response",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, request=request, response=response)
 
@@ -141,9 +141,9 @@ class TokenRefreshTimeoutError(TokenRefreshError):
     ----------
     message : str
         Error message describing the timeout (default: "Token refresh request timed out")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object (optional)
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object (optional)
     """
 
@@ -151,8 +151,8 @@ class TokenRefreshTimeoutError(TokenRefreshError):
         self,
         message: str = "Token refresh request timed out",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, request=request, response=response)
 
@@ -164,9 +164,9 @@ class TokenRefreshNetworkError(TokenRefreshError):
     ----------
     message : str
         Error message describing the network failure (default: "Token refresh request failed due to network issues")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object (optional)
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object (optional)
     """
 
@@ -174,8 +174,8 @@ class TokenRefreshNetworkError(TokenRefreshError):
         self,
         message: str = "Token refresh request failed due to network issues",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, request=request, response=response)
 
@@ -187,9 +187,9 @@ class AuthStrategyError(AuthenticationError):
     ----------
     message : str
         Error message describing the authentication strategy error (default: "Authentication strategy error")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object (optional)
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object (optional)
     """
 
@@ -197,7 +197,7 @@ class AuthStrategyError(AuthenticationError):
         self,
         message: str = "Authentication strategy error",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, request=request, response=response)

--- a/apiconfig/exceptions/base.py
+++ b/apiconfig/exceptions/base.py
@@ -2,7 +2,7 @@
 
 from typing import Any, List, Optional
 
-from apiconfig.types import HttpRequestProtocol, HttpResponseProtocol
+import apiconfig.types as api_types
 
 __all__: list[str] = [
     "APIConfigError",
@@ -24,7 +24,10 @@ class HttpContextMixin:
     """Mixin to add HTTP context extraction capabilities to exceptions."""
 
     def _init_http_context(
-        self, request: Optional[HttpRequestProtocol] = None, response: Optional[HttpResponseProtocol] = None, status_code: Optional[int] = None
+        self,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
+        status_code: Optional[int] = None,
     ) -> None:
         """Initialize HTTP context attributes from request/response objects."""
         # Initialize all attributes
@@ -89,9 +92,9 @@ class AuthenticationError(APIConfigError, HttpContextMixin):
     ----------
     message : str
         Error message describing the authentication failure
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object (optional)
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object (optional)
     *args : Any
         Additional positional arguments for base exception
@@ -103,8 +106,8 @@ class AuthenticationError(APIConfigError, HttpContextMixin):
         self,
         message: str,
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         """
         Initialize authentication error with optional HTTP context.
@@ -113,9 +116,9 @@ class AuthenticationError(APIConfigError, HttpContextMixin):
         ----------
         message : str
             Error message describing the authentication failure
-        request : Optional[HttpRequestProtocol]
+        request : Optional[api_types.HttpRequestProtocol]
             HTTP request object (optional)
-        response : Optional[HttpResponseProtocol]
+        response : Optional[api_types.HttpResponseProtocol]
             HTTP response object (optional)
         """
         super().__init__(message)

--- a/apiconfig/exceptions/http.py
+++ b/apiconfig/exceptions/http.py
@@ -8,7 +8,7 @@ exceptions where applicable.
 import json
 from typing import Any, Dict, List, Optional, Type, cast, final
 
-from apiconfig.types import HttpRequestProtocol, HttpResponseProtocol
+import apiconfig.types as api_types
 
 from .base import APIConfigError, AuthenticationError, HttpContextMixin
 
@@ -93,9 +93,9 @@ class ApiClientError(APIConfigError, HttpContextMixin):
         Error message describing the API client failure
     status_code : Optional[int]
         HTTP status code associated with the error
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object
     """
 
@@ -104,8 +104,8 @@ class ApiClientError(APIConfigError, HttpContextMixin):
         message: str,
         status_code: Optional[int] = None,
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         """
         Initialize API client error with HTTP context.
@@ -116,9 +116,9 @@ class ApiClientError(APIConfigError, HttpContextMixin):
             Error message describing the API client failure
         status_code : Optional[int]
             HTTP status code associated with the error
-        request : Optional[HttpRequestProtocol]
+        request : Optional[api_types.HttpRequestProtocol]
             HTTP request object
-        response : Optional[HttpResponseProtocol]
+        response : Optional[api_types.HttpResponseProtocol]
             HTTP response object
         """
         super().__init__(message)
@@ -150,9 +150,9 @@ class ApiClientBadRequestError(ApiClientError):
     ----------
     message : str
         Error message describing the bad request (default: "Bad Request")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object
     """
 
@@ -160,8 +160,8 @@ class ApiClientBadRequestError(ApiClientError):
         self,
         message: str = "Bad Request",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, status_code=400, request=request, response=response)
 
@@ -178,9 +178,9 @@ class ApiClientUnauthorizedError(ApiClientError, AuthenticationError):
     ----------
     message : str
         Error message describing the unauthorized access (default: "Unauthorized")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object
     """
 
@@ -188,8 +188,8 @@ class ApiClientUnauthorizedError(ApiClientError, AuthenticationError):
         self,
         message: str = "Unauthorized",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         # Only call ApiClientError.__init__ since it already handles HTTP context initialization
         ApiClientError.__init__(self, message, status_code=401, request=request, response=response)
@@ -208,9 +208,9 @@ class ApiClientForbiddenError(ApiClientError):
     ----------
     message : str
         Error message describing the forbidden access (default: "Forbidden")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object
     """
 
@@ -218,8 +218,8 @@ class ApiClientForbiddenError(ApiClientError):
         self,
         message: str = "Forbidden",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, status_code=403, request=request, response=response)
 
@@ -232,9 +232,9 @@ class ApiClientNotFoundError(ApiClientError):
     ----------
     message : str
         Error message describing the not found resource (default: "Not Found")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object
     """
 
@@ -242,8 +242,8 @@ class ApiClientNotFoundError(ApiClientError):
         self,
         message: str = "Not Found",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, status_code=404, request=request, response=response)
 
@@ -256,9 +256,9 @@ class ApiClientConflictError(ApiClientError):
     ----------
     message : str
         Error message describing the conflict (default: "Conflict")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object
     """
 
@@ -266,8 +266,8 @@ class ApiClientConflictError(ApiClientError):
         self,
         message: str = "Conflict",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, status_code=409, request=request, response=response)
 
@@ -280,9 +280,9 @@ class ApiClientUnprocessableEntityError(ApiClientError):
     ----------
     message : str
         Error message describing the unprocessable entity (default: "Unprocessable Entity")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object
     """
 
@@ -290,8 +290,8 @@ class ApiClientUnprocessableEntityError(ApiClientError):
         self,
         message: str = "Unprocessable Entity",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, status_code=422, request=request, response=response)
 
@@ -304,9 +304,9 @@ class ApiClientRateLimitError(ApiClientError):
     ----------
     message : str
         Error message describing the rate limit (default: "Rate Limit Exceeded")
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object
     """
 
@@ -314,8 +314,8 @@ class ApiClientRateLimitError(ApiClientError):
         self,
         message: str = "Rate Limit Exceeded",
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, status_code=429, request=request, response=response)
 
@@ -330,9 +330,9 @@ class ApiClientInternalServerError(ApiClientError):
         Error message describing the server error (default: "Internal Server Error")
     status_code : int
         HTTP status code (default: 500)
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object
     """
 
@@ -341,8 +341,8 @@ class ApiClientInternalServerError(ApiClientError):
         message: str = "Internal Server Error",
         status_code: int = 500,
         *,
-        request: Optional[HttpRequestProtocol] = None,
-        response: Optional[HttpResponseProtocol] = None,
+        request: Optional[api_types.HttpRequestProtocol] = None,
+        response: Optional[api_types.HttpResponseProtocol] = None,
     ) -> None:
         super().__init__(message, status_code=status_code, request=request, response=response)
 
@@ -351,8 +351,8 @@ def create_api_client_error(
     status_code: int,
     message: Optional[str] = None,
     *,
-    request: Optional[HttpRequestProtocol] = None,
-    response: Optional[HttpResponseProtocol] = None,
+    request: Optional[api_types.HttpRequestProtocol] = None,
+    response: Optional[api_types.HttpResponseProtocol] = None,
 ) -> ApiClientError:
     """
     Create appropriate ApiClientError subclass based on HTTP status code.
@@ -367,9 +367,9 @@ def create_api_client_error(
         HTTP status code
     message : Optional[str]
         Custom error message (uses default if not provided)
-    request : Optional[HttpRequestProtocol]
+    request : Optional[api_types.HttpRequestProtocol]
         HTTP request object
-    response : Optional[HttpResponseProtocol]
+    response : Optional[api_types.HttpResponseProtocol]
         HTTP response object
 
     Returns

--- a/tests/unit/test_exception_protocols.py
+++ b/tests/unit/test_exception_protocols.py
@@ -5,12 +5,12 @@ from unittest.mock import Mock
 
 import pytest
 
+import apiconfig.types as api_types
 from apiconfig.exceptions.auth import AuthenticationError, TokenRefreshError
 from apiconfig.exceptions.http import (
     ApiClientError,
     create_api_client_error,
 )
-from apiconfig.types import HttpRequestProtocol
 
 
 class TestProtocolCompliance:
@@ -26,7 +26,7 @@ class TestProtocolCompliance:
                 self.headers: dict[str, str] = {}
 
         request = MinimalRequest()
-        assert isinstance(request, HttpRequestProtocol)
+        assert isinstance(request, api_types.HttpRequestProtocol)
 
         error = ApiClientError("Test", request=request)
         assert error.method == "GET"
@@ -81,7 +81,7 @@ class TestProtocolCompliance:
         # Simple object that happens to have the right attributes
         request = type("Request", (), {"method": "PUT", "url": "https://api.example.com/resource/123", "headers": {}})()
 
-        request_obj: HttpRequestProtocol = cast(HttpRequestProtocol, request)
+        request_obj: api_types.HttpRequestProtocol = cast(api_types.HttpRequestProtocol, request)
         error = ApiClientError("Update failed", request=request_obj)
         assert error.method == "PUT"
         assert error.url == "https://api.example.com/resource/123"


### PR DESCRIPTION
## Summary
- alias `apiconfig.types` as `api_types`
- update exception modules and tests to reference `api_types.HttpRequestProtocol`

## Testing
- `pre-commit run --files apiconfig/exceptions/auth.py apiconfig/exceptions/base.py apiconfig/exceptions/http.py tests/unit/test_exception_protocols.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68699caa6e8083329e8976ecc30acddc