### PR TITLE
Update import alias in base client test

### DIFF
--- a/tests/unit/helpers/common/test_base_client.py
+++ b/tests/unit/helpers/common/test_base_client.py
@@ -3,10 +3,10 @@ from typing import Dict, Optional
 import httpx
 import pytest
 
+import apiconfig.types as api_types
 from apiconfig.auth.base import AuthStrategy
 from apiconfig.config.base import ClientConfig
 from apiconfig.exceptions.http import HTTPUtilsError, JSONDecodeError
-from apiconfig.types import HttpMethod, QueryParamType
 from helpers_for_tests.common.base_client import BaseClient
 
 
@@ -14,7 +14,7 @@ class DummyAuthStrategy(AuthStrategy):
     def prepare_request_headers(self) -> Dict[str, str]:
         return {}
 
-    def prepare_request_params(self) -> Optional[QueryParamType]:
+    def prepare_request_params(self) -> Optional[api_types.QueryParamType]:
         return None
 
 
@@ -31,13 +31,21 @@ def test_handle_response_raises_on_error_status() -> None:
     client = _make_client()
     response = httpx.Response(status_code=404, text="not found")
     with pytest.raises(HTTPUtilsError):
-        client._handle_response(response, HttpMethod.GET, "https://example.com/test")  # pyright: ignore[reportPrivateUsage]
+        client._handle_response(
+            response,
+            api_types.HttpMethod.GET,
+            "https://example.com/test",
+        )  # pyright: ignore[reportPrivateUsage]
 
 
 def test_handle_response_parses_json() -> None:
     client = _make_client()
     response = httpx.Response(status_code=200, json={"ok": True})
-    result = client._handle_response(response, HttpMethod.GET, "https://example.com/test")  # pyright: ignore[reportPrivateUsage]
+    result = client._handle_response(
+        response,
+        api_types.HttpMethod.GET,
+        "https://example.com/test",
+    )  # pyright: ignore[reportPrivateUsage]
     assert result == {"ok": True}
 
 
@@ -45,7 +53,11 @@ def test_handle_response_invalid_json() -> None:
     client = _make_client()
     response = httpx.Response(status_code=200, text="{invalid json")
     with pytest.raises(JSONDecodeError):
-        client._handle_response(response, HttpMethod.GET, "https://example.com/test")  # pyright: ignore[reportPrivateUsage]
+        client._handle_response(
+            response,
+            api_types.HttpMethod.GET,
+            "https://example.com/test",
+        )  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.mark.parametrize("body", ["", "null", "123", '"text"'])
@@ -53,5 +65,9 @@ def test_handle_response_empty_or_non_object_returns_empty_dict(body: str) -> No
     """Non-object JSON bodies should result in an empty dict."""
     client = _make_client()
     response = httpx.Response(status_code=200, text=body)
-    result = client._handle_response(response, HttpMethod.GET, "https://example.com/test")  # pyright: ignore[reportPrivateUsage]
+    result = client._handle_response(
+        response,
+        api_types.HttpMethod.GET,
+        "https://example.com/test",
+    )  # pyright: ignore[reportPrivateUsage]
     assert result == {}


### PR DESCRIPTION
## Summary
- refactor tests to use an alias for common HTTP types

## Testing
- `poetry run pre-commit run --files tests/unit/helpers/common/test_base_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68699caa77e883328295437827a31a49