### PR TITLE
Centralize regex imports in tests

### DIFF
--- a/tests/unit/config/providers/test_file.py
+++ b/tests/unit/config/providers/test_file.py
@@ -3,6 +3,7 @@
 import json
 import os
 import pathlib
+import re
 import sys
 import tempfile
 from pathlib import Path
@@ -65,8 +66,6 @@ class TestFileProvider:
 
             provider = FileProvider(file_path=temp_file.name)
 
-            import re
-
             # Match the new error message with colon and normalized path
             expected_path = re.escape(os.path.normpath(temp_file.name))
             pattern = rf"must contain a JSON object: {expected_path}"
@@ -76,7 +75,6 @@ class TestFileProvider:
     def test_load_file_not_found(self) -> None:
         """Test loading a file that doesn't exist."""
         # Use a path that definitely doesn't exist
-        import re
 
         non_existent_path = os.path.join("path", "that", "definitely", "does", "not", "exist", "config.json")
         provider = FileProvider(file_path=non_existent_path)
@@ -96,8 +94,6 @@ class TestFileProvider:
             temp_file.flush()
 
             provider = FileProvider(file_path=temp_file.name)
-
-            import re
 
             # Match the new error message with colon and normalized path
             expected_path = re.escape(os.path.normpath(temp_file.name))

--- a/tests/unit/utils/logging/formatters/test_redacting.py
+++ b/tests/unit/utils/logging/formatters/test_redacting.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Callable, cast
 
 import pytest
@@ -141,8 +142,6 @@ def test_redacting_formatter_headers_redaction(
 def test_redacting_formatter_plain_string_secret(
     log_record_factory: Callable[..., logging.LogRecord],
 ) -> None:
-    import re
-
     secret_pattern = re.compile(r"secret_[a-z0-9]+", re.IGNORECASE)
     fmt = RedactingFormatter(body_sensitive_value_pattern=secret_pattern)
     record = log_record_factory(msg="this is a secret_abc123 and should be redacted")


### PR DESCRIPTION
## Summary
- add module-level `import re` statements
- remove per-function imports that shadow the module

## Testing
- `poetry run pre-commit run --files tests/unit/config/providers/test_file.py tests/unit/utils/logging/formatters/test_redacting.py`
- `poetry run pytest tests/unit/config/providers/test_file.py tests/unit/utils/logging/formatters/test_redacting.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68699caa384c8332a3015ecf15331647