### PR TITLE
Fix pyright shadowed import warning in HTTP tests

### DIFF
--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -1,6 +1,6 @@
 """Unit tests for apiconfig.utils.http module."""
 
-from typing import Any
+from typing import Any  # pyright: ignore[reportShadowedImports]
 
 import pytest
 


### PR DESCRIPTION
## Summary
- ignore pyright shadowed import in HTTP test

## Testing
- `poetry run pytest tests/unit/utils/test_http.py -q`
- `poetry run pre-commit run --files tests/unit/utils/test_http.py`

------
https://chatgpt.com/codex/tasks/task_e_68699c98257c8332aebcf2d469599dc2