### PR TITLE
Refactor time imports

### DIFF
--- a/apiconfig/auth/token/refresh.py
+++ b/apiconfig/auth/token/refresh.py
@@ -8,7 +8,7 @@ It includes retry logic for transient errors.
 
 import json
 import logging
-import time
+import time as time_mod
 
 # Import httpx only for type annotations, not for actual use
 # This allows for proper type checking without runtime dependency
@@ -202,7 +202,7 @@ def _make_token_refresh_request(
 
     try:
         logger.debug(f"Making token refresh request to {token_url}")
-        start_time = time.time()
+        start_time = time_mod.time()
 
         # Make the HTTP request using the provided client
         response = http_client.post(
@@ -212,7 +212,7 @@ def _make_token_refresh_request(
             timeout=timeout,
         )
 
-        elapsed = time.time() - start_time
+        elapsed = time_mod.time() - start_time
         logger.debug(f"Token refresh request completed in {elapsed:.2f}s")
 
         # Check for HTTP errors
@@ -390,7 +390,7 @@ def _execute_with_retry(
             if attempt > 0:
                 backoff_time = min(2**attempt, 10)  # Exponential backoff with max of 10 seconds
                 logger.debug(f"Retry attempt {attempt + 1}/{max_retries}, waiting {backoff_time}s")
-                time.sleep(backoff_time)
+                time_mod.sleep(backoff_time)
 
             # Make the request
             token_data = _make_token_refresh_request(

--- a/apiconfig/testing/unit/mocks/auth.py
+++ b/apiconfig/testing/unit/mocks/auth.py
@@ -3,7 +3,7 @@
 
 import random
 import threading
-import time
+import time as time_mod
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from apiconfig.auth.base import AuthStrategy
@@ -297,7 +297,7 @@ class MockRefreshableAuthStrategy(MockAuthStrategy):
             True if credentials are known to be expired, False otherwise.
         """
         # Check timestamp-based expiry first
-        if self._expiry_time is not None and time.time() >= self._expiry_time:
+        if self._expiry_time is not None and time_mod.time() >= self._expiry_time:
             return True
         return self._is_expired
 
@@ -326,7 +326,7 @@ class MockRefreshableAuthStrategy(MockAuthStrategy):
             If refresh fails due to configuration or attempt limits.
         """
         if self._refresh_delay > 0:
-            time.sleep(self._refresh_delay)
+            time_mod.sleep(self._refresh_delay)
 
         # Check if refresh is available before incrementing attempts
         if not self.can_refresh():
@@ -567,7 +567,7 @@ class AuthTestScenarioBuilder:
 
         # Set expiry time based on current time + expiry duration
         # This avoids race conditions with background threads
-        strategy._expiry_time = time.time() + expires_after_seconds  # pyright: ignore[reportPrivateUsage]
+        strategy._expiry_time = time_mod.time() + expires_after_seconds  # pyright: ignore[reportPrivateUsage]
         return strategy
 
     @staticmethod
@@ -697,7 +697,7 @@ class MockHttpRequestCallable:
         self.call_history.append({"method": method, "url": url, "kwargs": kwargs})
 
         if self.delay > 0:
-            time.sleep(self.delay)
+            time_mod.sleep(self.delay)
 
         if random.random() < self.failure_rate:
             raise ConnectionError("Mock HTTP failure")

--- a/tests/component/test_enhanced_auth_mocks_refresh.py
+++ b/tests/component/test_enhanced_auth_mocks_refresh.py
@@ -1,7 +1,7 @@
 """Component tests for enhanced auth mocks refresh scenarios."""
 
 import threading
-import time
+import time as time_mod
 from typing import Dict
 
 import pytest
@@ -186,7 +186,7 @@ class TestEnhancedAuthMocksRefresh:
         assert not strategy.is_expired()
 
         # Wait for expiry
-        time.sleep(0.2)
+        time_mod.sleep(0.2)
 
         # Should now be expired
         assert strategy.is_expired()
@@ -283,9 +283,9 @@ class TestEnhancedAuthMocksRefresh:
         """Test MockHttpRequestCallable with delay."""
         mock_http = MockHttpRequestCallable(delay=0.1)
 
-        start_time = time.time()
+        start_time = time_mod.time()
         response = mock_http("GET", "/test")
-        end_time = time.time()
+        end_time = time_mod.time()
 
         # Should have taken at least 0.1 seconds
         assert end_time - start_time >= 0.1

--- a/tests/component/test_phase2_cross_component_integration.py
+++ b/tests/component/test_phase2_cross_component_integration.py
@@ -1,7 +1,7 @@
 """Component tests for Phase 2 cross-component integration."""
 
 import base64
-import time
+import time as time_mod
 from typing import Dict, List
 
 import pytest
@@ -142,7 +142,7 @@ class TestPhase2CrossComponentIntegration:
         assert AuthHeaderVerification.verify_bearer_auth_header(headers["Authorization"])
 
         # Wait for expiry
-        time.sleep(0.2)
+        time_mod.sleep(0.2)
         assert expiry_strategy.is_expired()
 
         # Headers should still be verifiable (token doesn't change until refresh)
@@ -299,7 +299,7 @@ class TestPhase2CrossComponentIntegration:
             strategies.append(strategy)
 
         # Measure time for auth application and verification
-        start_time = time.time()
+        start_time = time_mod.time()
 
         for strategy in strategies:
             headers: Dict[str, str] = {}
@@ -314,7 +314,7 @@ class TestPhase2CrossComponentIntegration:
                 strategy.apply_auth(new_headers)
                 AuthHeaderVerification.verify_bearer_auth_header(new_headers["Authorization"])
 
-        end_time = time.time()
+        end_time = time_mod.time()
 
         # Should complete quickly (less than 1 second for 10 strategies)
         assert end_time - start_time < 1.0

--- a/tests/component/test_refresh_error_handling.py
+++ b/tests/component/test_refresh_error_handling.py
@@ -1,7 +1,7 @@
 """Test error handling in refresh scenarios."""
 
 import threading
-import time
+import time as time_mod
 from typing import Any
 from unittest.mock import Mock
 
@@ -49,7 +49,7 @@ class TestRefreshErrorHandling:
     def test_concurrent_refresh_safety(self) -> None:
         """Test thread safety of concurrent refresh operations."""
         mock_http = Mock()
-        mock_http.return_value = Mock(json=lambda: {"access_token": f"token_{time.time()}", "expires_in": 3600})
+        mock_http.return_value = Mock(json=lambda: {"access_token": f"token_{time_mod.time()}", "expires_in": 3600})
 
         # Create a test subclass with thread-safe refresh
         class TestBearerAuth(BearerAuth):
@@ -60,8 +60,8 @@ class TestRefreshErrorHandling:
             def refresh(self) -> TokenRefreshResult:
                 with self._refresh_lock:
                     # Simulate some processing time
-                    time.sleep(0.01)
-                    new_token = f"token_{time.time()}"
+                    time_mod.sleep(0.01)
+                    new_token = f"token_{time_mod.time()}"
                     self.access_token = new_token
                     return {"token_data": {"access_token": new_token}, "config_updates": None}
 

--- a/tests/component/test_refresh_performance.py
+++ b/tests/component/test_refresh_performance.py
@@ -1,6 +1,6 @@
 """Test performance characteristics of refresh operations."""
 
-import time
+import time as time_mod
 from typing import Any, Dict
 from unittest.mock import Mock
 
@@ -27,9 +27,9 @@ class TestRefreshPerformance:
         auth = TestBearerAuth(access_token="token", http_request_callable=mock_http)
 
         # Measure refresh time
-        start_time = time.time()
+        start_time = time_mod.time()
         auth.refresh()
-        refresh_time = time.time() - start_time
+        refresh_time = time_mod.time() - start_time
 
         # Should complete quickly (< 100ms excluding network)
         assert refresh_time < 0.1
@@ -39,9 +39,9 @@ class TestRefreshPerformance:
         auth = BearerAuth(access_token="token")
 
         # Measure callback creation time
-        start_time = time.time()
+        start_time = time_mod.time()
         auth.get_refresh_callback()  # Test callback creation overhead
-        callback_time = time.time() - start_time
+        callback_time = time_mod.time() - start_time
 
         # Should be negligible overhead
         assert callback_time < 0.01
@@ -61,18 +61,18 @@ class TestRefreshPerformance:
         auth = CustomAuth(header_callback=header_callback, refresh_func=refresh_func, can_refresh_func=lambda: True)
 
         # Measure header preparation time
-        start_time = time.time()
+        start_time = time_mod.time()
         headers = auth.prepare_request_headers()
-        header_time = time.time() - start_time
+        header_time = time_mod.time() - start_time
 
         # Should be very fast
         assert header_time < 0.01
         assert headers["Authorization"] == "Bearer token_1"
 
         # Measure refresh time
-        start_time = time.time()
+        start_time = time_mod.time()
         result = auth.refresh()
-        refresh_time = time.time() - start_time
+        refresh_time = time_mod.time() - start_time
 
         # Should be fast
         assert refresh_time < 0.01
@@ -98,10 +98,10 @@ class TestRefreshPerformance:
         auth = TestBearerAuth(access_token="initial_token", http_request_callable=Mock())
 
         # Measure time for multiple refreshes
-        start_time = time.time()
+        start_time = time_mod.time()
         for _ in range(10):
             auth.refresh()
-        total_time = time.time() - start_time
+        total_time = time_mod.time() - start_time
 
         # Should complete all refreshes quickly
         assert total_time < 0.1
@@ -123,9 +123,9 @@ class TestRefreshPerformance:
         assert callback is not None
 
         # Measure callback invocation time
-        start_time = time.time()
+        start_time = time_mod.time()
         callback()
-        callback_time = time.time() - start_time
+        callback_time = time_mod.time() - start_time
 
         # Should be very fast
         assert callback_time < 0.01

--- a/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
+++ b/tests/unit/testing/mocks/test_enhanced_auth_mocks.py
@@ -2,7 +2,7 @@
 """Unit tests for enhanced auth mocks with refresh scenarios."""
 
 import threading
-import time
+import time as time_mod
 from typing import Any, Dict, Optional
 from unittest.mock import patch
 
@@ -113,9 +113,9 @@ class TestMockRefreshableAuthStrategy:
         """Test refresh operation with delay."""
         strategy = MockRefreshableAuthStrategy(refresh_delay=0.1)
 
-        start_time = time.time()
+        start_time = time_mod.time()
         strategy.refresh()
-        end_time = time.time()
+        end_time = time_mod.time()
 
         assert end_time - start_time >= 0.1
 
@@ -377,7 +377,7 @@ class TestAuthTestScenarioBuilder:
         assert strategy.is_expired() is False
 
         # Wait for expiration
-        time.sleep(0.15)
+        time_mod.sleep(0.15)
         assert strategy.is_expired() is True
 
     def test_create_concurrent_refresh_scenario(self) -> None:
@@ -510,9 +510,9 @@ class TestMockHttpRequestCallable:
         """Test calling with delay."""
         mock_http = MockHttpRequestCallable(delay=0.1)
 
-        start_time = time.time()
+        start_time = time_mod.time()
         mock_http("GET", "http://example.com")
-        end_time = time.time()
+        end_time = time_mod.time()
 
         assert end_time - start_time >= 0.1
 


### PR DESCRIPTION
## Summary
- alias `time` imports as `time_mod`
- prevent variable name shadowing in tests and mocks

## Testing
- `poetry run pre-commit run --files apiconfig/auth/token/refresh.py apiconfig/testing/unit/mocks/auth.py tests/unit/testing/mocks/test_enhanced_auth_mocks.py tests/unit/testing/mocks/test_token_expiry_reliability.py tests/component/test_refresh_performance.py tests/component/test_enhanced_auth_mocks_refresh.py tests/component/test_phase2_cross_component_integration.py tests/component/test_refresh_error_handling.py`

------
https://chatgpt.com/codex/tasks/task_e_68699c86a7708332a068066429fd7cb0