### PR TITLE
Fix Mock imports in tests

### DIFF
--- a/tests/component/test_auth_refresh_interface.py
+++ b/tests/component/test_auth_refresh_interface.py
@@ -1,6 +1,6 @@
 """Test refresh interface consistency across auth strategies."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock as MockClass
 
 from apiconfig.auth.strategies.bearer import BearerAuth
 from apiconfig.auth.strategies.custom import CustomAuth
@@ -13,8 +13,8 @@ class TestAuthRefreshInterface:
     def test_refresh_interface_consistency(self) -> None:
         """Test that all refreshable strategies implement consistent interface."""
         # Mock HTTP callable
-        mock_http = Mock()
-        mock_http.return_value = Mock(json=lambda: {"access_token": "new_token", "refresh_token": "new_refresh", "expires_in": 3600})
+        mock_http = MockClass()
+        mock_http.return_value = MockClass(json=lambda: {"access_token": "new_token", "refresh_token": "new_refresh", "expires_in": 3600})
 
         # Create a test subclass of BearerAuth that implements refresh
         class TestBearerAuth(BearerAuth):
@@ -52,8 +52,8 @@ class TestAuthRefreshInterface:
 
     def test_crudclient_callback_compatibility(self) -> None:
         """Test compatibility with crudclient's setup_auth_func pattern."""
-        mock_http = Mock()
-        mock_http.return_value = Mock(json=lambda: {"access_token": "new_token", "expires_in": 3600})
+        mock_http = MockClass()
+        mock_http.return_value = MockClass(json=lambda: {"access_token": "new_token", "expires_in": 3600})
 
         # Create a test subclass that implements refresh
         class TestBearerAuth(BearerAuth):

--- a/tests/component/test_auth_verification_integration.py
+++ b/tests/component/test_auth_verification_integration.py
@@ -2,7 +2,7 @@
 
 import base64
 from typing import Dict
-from unittest.mock import Mock
+from unittest.mock import Mock as MockClass
 
 import pytest
 
@@ -23,7 +23,7 @@ class TestAuthVerificationIntegration:
     def test_basic_auth_verification_with_mock_strategy(self) -> None:
         """Test Basic Auth verification with mocked strategy."""
         # Create mock basic auth strategy
-        mock_basic_auth = Mock()
+        mock_basic_auth = MockClass()
         credentials = base64.b64encode(b"user:pass").decode()
         mock_basic_auth.prepare_request_headers.return_value = {"Authorization": f"Basic {credentials}"}
 
@@ -39,7 +39,7 @@ class TestAuthVerificationIntegration:
     def test_bearer_auth_verification_with_mock_strategy(self) -> None:
         """Test Bearer Auth verification with mocked strategy."""
         # Create mock bearer auth strategy
-        mock_bearer_auth = Mock()
+        mock_bearer_auth = MockClass()
         mock_bearer_auth.prepare_request_headers.return_value = {"Authorization": "Bearer test_token_12345"}
 
         # Get headers from mock
@@ -57,7 +57,7 @@ class TestAuthVerificationIntegration:
     def test_api_key_verification_with_mock_strategy(self) -> None:
         """Test API Key verification with mocked strategy."""
         # Create mock API key auth strategy
-        mock_api_key_auth = Mock()
+        mock_api_key_auth = MockClass()
         mock_api_key_auth.prepare_request_headers.return_value = {"X-API-Key": "sk-test_key_123"}
 
         # Get headers from mock
@@ -75,10 +75,10 @@ class TestAuthVerificationIntegration:
     def test_multiple_auth_headers_verification_with_mocks(self) -> None:
         """Test multiple auth headers verification with mocked strategies."""
         # Create mock strategies
-        mock_bearer = Mock()
+        mock_bearer = MockClass()
         mock_bearer.prepare_request_headers.return_value = {"Authorization": "Bearer bearer_token_123"}
 
-        mock_api_key = Mock()
+        mock_api_key = MockClass()
         mock_api_key.prepare_request_headers.return_value = {"X-API-Key": "api_key_456"}
 
         # Combine headers

--- a/tests/component/test_end_to_end_refresh.py
+++ b/tests/component/test_end_to_end_refresh.py
@@ -1,7 +1,8 @@
 """Test complete refresh flows from trigger to completion."""
 
 from typing import Dict, Optional
-from unittest.mock import Mock, patch
+from unittest.mock import Mock as MockClass
+from unittest.mock import patch
 
 from apiconfig.auth.strategies.bearer import BearerAuth
 from apiconfig.auth.strategies.custom import CustomAuth
@@ -12,7 +13,7 @@ class TestEndToEndRefresh:
     """Test complete refresh flows from trigger to completion."""
 
     @patch("apiconfig.auth.token.refresh.refresh_oauth2_token")
-    def test_bearer_token_refresh_flow(self, mock_refresh: Mock) -> None:
+    def test_bearer_token_refresh_flow(self, mock_refresh: MockClass) -> None:
         """Test complete Bearer token refresh flow."""
         # Setup mock response
         mock_refresh.return_value = {
@@ -30,7 +31,7 @@ class TestEndToEndRefresh:
                 refresh_token: Optional[str] = None,
                 token_url: Optional[str] = None,
                 client_id: Optional[str] = None,
-                http_request_callable: Optional[Mock] = None,
+                http_request_callable: Optional[MockClass] = None,
             ) -> None:
                 super().__init__(access_token, http_request_callable=http_request_callable)
                 self.refresh_token = refresh_token
@@ -59,7 +60,7 @@ class TestEndToEndRefresh:
             refresh_token="old_refresh",
             token_url="https://example.com/token",
             client_id="test_client",
-            http_request_callable=Mock(),
+            http_request_callable=MockClass(),
         )
 
         # Simulate refresh trigger

--- a/tests/component/test_existing_component_integration.py
+++ b/tests/component/test_existing_component_integration.py
@@ -3,7 +3,7 @@
 import logging
 from io import StringIO
 from typing import Any, Dict
-from unittest.mock import Mock
+from unittest.mock import Mock as MockClass
 
 from apiconfig.auth.strategies.bearer import BearerAuth
 from apiconfig.auth.strategies.custom import CustomAuth
@@ -44,8 +44,8 @@ class TestExistingComponentIntegration:
                 return {"token_data": {"access_token": "new_token", "refresh_token": "new_refresh"}, "config_updates": None}
 
         # Test saving back to storage after refresh
-        mock_http = Mock()
-        mock_http.return_value = Mock(json=lambda: {"access_token": "new_token", "refresh_token": "new_refresh"})
+        mock_http = MockClass()
+        mock_http.return_value = MockClass(json=lambda: {"access_token": "new_token", "refresh_token": "new_refresh"})
 
         auth = TestBearerAuth(access_token="stored_token", http_request_callable=mock_http)
         auth.refresh_token = "stored_refresh"
@@ -77,8 +77,8 @@ class TestExistingComponentIntegration:
         logger.setLevel(logging.INFO)
 
         try:
-            mock_http = Mock()
-            mock_http.return_value = Mock(json=lambda: {"access_token": "new_token"})
+            mock_http = MockClass()
+            mock_http.return_value = MockClass(json=lambda: {"access_token": "new_token"})
 
             # Create a test subclass that logs during refresh
             class TestBearerAuth(BearerAuth):

--- a/tests/component/test_phase2_error_scenarios.py
+++ b/tests/component/test_phase2_error_scenarios.py
@@ -3,7 +3,7 @@
 import base64
 import json
 from typing import Dict
-from unittest.mock import Mock
+from unittest.mock import Mock as MockClass
 
 import pytest
 
@@ -293,7 +293,7 @@ class TestPhase2ErrorScenarios:
             AuthHeaderVerification.verify_basic_auth_header("Basic !!invalid_base64!!")
 
         # Test verification with None values (should be handled gracefully)
-        mock_strategy = Mock()
+        mock_strategy = MockClass()
         mock_strategy.prepare_request_headers.return_value = {"Authorization": None}
 
         headers = mock_strategy.prepare_request_headers()

--- a/tests/component/test_refresh_error_handling.py
+++ b/tests/component/test_refresh_error_handling.py
@@ -3,7 +3,7 @@
 import threading
 import time
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import Mock as MockClass
 
 import pytest
 
@@ -18,7 +18,7 @@ class TestRefreshErrorHandling:
 
     def test_refresh_failure_handling(self) -> None:
         """Test handling of refresh failures."""
-        mock_http = Mock()
+        mock_http = MockClass()
         mock_http.side_effect = Exception("Network error")
 
         # Create a test subclass that uses the http_request_callable
@@ -48,8 +48,8 @@ class TestRefreshErrorHandling:
 
     def test_concurrent_refresh_safety(self) -> None:
         """Test thread safety of concurrent refresh operations."""
-        mock_http = Mock()
-        mock_http.return_value = Mock(json=lambda: {"access_token": f"token_{time.time()}", "expires_in": 3600})
+        mock_http = MockClass()
+        mock_http.return_value = MockClass(json=lambda: {"access_token": f"token_{time.time()}", "expires_in": 3600})
 
         # Create a test subclass with thread-safe refresh
         class TestBearerAuth(BearerAuth):

--- a/tests/component/test_refresh_performance.py
+++ b/tests/component/test_refresh_performance.py
@@ -2,7 +2,7 @@
 
 import time
 from typing import Any, Dict
-from unittest.mock import Mock
+from unittest.mock import Mock as MockClass
 
 from apiconfig.auth.strategies.bearer import BearerAuth
 from apiconfig.auth.strategies.custom import CustomAuth
@@ -14,8 +14,8 @@ class TestRefreshPerformance:
 
     def test_refresh_performance(self) -> None:
         """Test refresh operation performance."""
-        mock_http = Mock()
-        mock_http.return_value = Mock(json=lambda: {"access_token": "new_token", "expires_in": 3600})
+        mock_http = MockClass()
+        mock_http.return_value = MockClass(json=lambda: {"access_token": "new_token", "expires_in": 3600})
 
         # Create a test subclass that implements refresh
         class TestBearerAuth(BearerAuth):
@@ -95,7 +95,7 @@ class TestRefreshPerformance:
                 self.access_token = f"token_{self.refresh_count}"
                 return {"token_data": {"access_token": self.access_token}, "config_updates": None}
 
-        auth = TestBearerAuth(access_token="initial_token", http_request_callable=Mock())
+        auth = TestBearerAuth(access_token="initial_token", http_request_callable=MockClass())
 
         # Measure time for multiple refreshes
         start_time = time.time()
@@ -117,7 +117,7 @@ class TestRefreshPerformance:
                 self.access_token = "refreshed_token"
                 return {"token_data": {"access_token": "refreshed_token"}, "config_updates": None}
 
-        auth = TestBearerAuth(access_token="initial_token", http_request_callable=Mock())
+        auth = TestBearerAuth(access_token="initial_token", http_request_callable=MockClass())
 
         callback = auth.get_refresh_callback()
         assert callback is not None

--- a/tests/unit/auth/strategies/test_bearer.py
+++ b/tests/unit/auth/strategies/test_bearer.py
@@ -1,7 +1,7 @@
 """Tests for the BearerAuth strategy."""
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import Mock
+from unittest.mock import Mock as MockClass
 
 import pytest
 
@@ -22,7 +22,7 @@ class TestBearerAuth:
     def test_init_with_all_parameters(self) -> None:
         """Test initialization with all parameters."""
         expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        http_callable = Mock()
+        http_callable = MockClass()
 
         auth = BearerAuth(access_token="valid_token", expires_at=expires_at, http_request_callable=http_callable)
 
@@ -47,7 +47,7 @@ class TestBearerAuth:
 
     def test_can_refresh_with_http_callable(self) -> None:
         """Test can_refresh returns True when HTTP callable is provided."""
-        http_callable = Mock()
+        http_callable = MockClass()
         auth = BearerAuth(access_token="test_token", http_request_callable=http_callable)
         assert auth.can_refresh() is True
 
@@ -90,7 +90,7 @@ class TestBearerAuth:
 
     def test_refresh_raises_not_implemented_when_refreshable(self) -> None:
         """Test refresh raises NotImplementedError when refreshable but no custom logic."""
-        http_callable = Mock()
+        http_callable = MockClass()
         auth = BearerAuth(access_token="test_token", http_request_callable=http_callable)
 
         with pytest.raises(NotImplementedError, match="Bearer auth refresh requires custom implementation"):
@@ -113,7 +113,7 @@ class TestBearerAuth:
     def test_prepare_request_headers_with_expired_refreshable_token(self) -> None:
         """Test prepare_request_headers works with expired but refreshable token."""
         expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
-        http_callable = Mock()
+        http_callable = MockClass()
         auth = BearerAuth(access_token="test_token", expires_at=expires_at, http_request_callable=http_callable)
 
         # Should not raise ExpiredTokenError since token can be refreshed
@@ -134,7 +134,7 @@ class TestBearerAuth:
 
     def test_get_refresh_callback_with_refresh_capability(self) -> None:
         """Test get_refresh_callback returns a callable when refresh is supported."""
-        http_callable = Mock()
+        http_callable = MockClass()
         auth = BearerAuth(access_token="test_token", http_request_callable=http_callable)
         callback = auth.get_refresh_callback()
 

--- a/tests/unit/auth/strategies/test_custom.py
+++ b/tests/unit/auth/strategies/test_custom.py
@@ -1,7 +1,7 @@
 """Tests for the CustomAuth strategy."""
 
 from typing import Dict, Optional
-from unittest.mock import Mock
+from unittest.mock import Mock as MockClass
 
 import pytest
 
@@ -30,10 +30,10 @@ class TestCustomAuth:
 
     def test_init_with_refresh_functions(self) -> None:
         """Test initialization with refresh-related functions."""
-        refresh_func = Mock(return_value={"token_data": {"access_token": "new_token"}})
-        can_refresh_func = Mock(return_value=True)
-        is_expired_func = Mock(return_value=False)
-        http_request_callable = Mock()
+        refresh_func = MockClass(return_value={"token_data": {"access_token": "new_token"}})
+        can_refresh_func = MockClass(return_value=True)
+        is_expired_func = MockClass(return_value=False)
+        http_request_callable = MockClass()
 
         auth = CustomAuth(
             header_callback=lambda: {"Authorization": "Bearer token"},
@@ -50,7 +50,7 @@ class TestCustomAuth:
 
     def test_can_refresh_with_can_refresh_func(self) -> None:
         """Test can_refresh when can_refresh_func is provided."""
-        can_refresh_func = Mock(return_value=True)
+        can_refresh_func = MockClass(return_value=True)
         auth = CustomAuth(
             header_callback=lambda: {},
             can_refresh_func=can_refresh_func,
@@ -62,7 +62,7 @@ class TestCustomAuth:
 
     def test_can_refresh_without_can_refresh_func_with_refresh_func(self) -> None:
         """Test can_refresh when only refresh_func is provided."""
-        refresh_func = Mock()
+        refresh_func = MockClass()
         auth = CustomAuth(
             header_callback=lambda: {},
             refresh_func=refresh_func,
@@ -80,7 +80,7 @@ class TestCustomAuth:
 
     def test_is_expired_with_is_expired_func(self) -> None:
         """Test is_expired when is_expired_func is provided."""
-        is_expired_func = Mock(return_value=True)
+        is_expired_func = MockClass(return_value=True)
         auth = CustomAuth(
             header_callback=lambda: {},
             is_expired_func=is_expired_func,
@@ -103,7 +103,7 @@ class TestCustomAuth:
             "token_data": {"access_token": "new_token"},
             "config_updates": None,
         }
-        refresh_func = Mock(return_value=expected_result)
+        refresh_func = MockClass(return_value=expected_result)
         auth = CustomAuth(
             header_callback=lambda: {},
             refresh_func=refresh_func,
@@ -122,7 +122,7 @@ class TestCustomAuth:
 
     def test_refresh_with_failing_refresh_func(self) -> None:
         """Test refresh when refresh_func raises an exception."""
-        refresh_func = Mock(side_effect=ValueError("Refresh failed"))
+        refresh_func = MockClass(side_effect=ValueError("Refresh failed"))
         auth = CustomAuth(
             header_callback=lambda: {},
             refresh_func=refresh_func,
@@ -307,7 +307,7 @@ class TestCustomAuthFactoryMethods:
 
     def test_create_api_key_custom_with_http_request_callable(self) -> None:
         """Test create_api_key_custom with http_request_callable."""
-        http_callable = Mock()
+        http_callable = MockClass()
         auth = CustomAuth.create_api_key_custom(api_key="test-key", http_request_callable=http_callable)
 
         assert auth._http_request_callable is http_callable  # pyright: ignore[reportPrivateUsage]
@@ -369,7 +369,7 @@ class TestCustomAuthFactoryMethods:
 
     def test_create_session_token_custom_with_http_request_callable(self) -> None:
         """Test create_session_token_custom with http_request_callable."""
-        http_callable = Mock()
+        http_callable = MockClass()
 
         def mock_refresh_func() -> str:
             return "refreshed-token"

--- a/tests/unit/auth/test_auth_base.py
+++ b/tests/unit/auth/test_auth_base.py
@@ -1,7 +1,8 @@
 """Unit tests for the AuthStrategy base class."""
 
 from typing import Any, Callable, Dict, Optional, cast
-from unittest.mock import Mock, patch
+from unittest.mock import Mock as MockClass
+from unittest.mock import patch
 
 import pytest
 
@@ -65,7 +66,7 @@ class TestAuthStrategy:
 
     def test_init_with_http_request_callable(self) -> None:
         """Test initialization with http_request_callable."""
-        mock_callable = Mock()
+        mock_callable = MockClass()
         strategy = ConcreteAuthStrategy(http_request_callable=mock_callable)
         assert strategy._http_request_callable is mock_callable  # pyright: ignore[reportPrivateUsage]
 
@@ -93,7 +94,7 @@ class TestAuthStrategy:
 
     def test_get_refresh_callback_returns_callable_when_can_refresh(self) -> None:
         """Test that get_refresh_callback returns a callable when can_refresh is True."""
-        mock_callable = Mock()
+        mock_callable = MockClass()
         strategy = RefreshableAuthStrategy(http_request_callable=mock_callable)
         callback = strategy.get_refresh_callback()
 
@@ -102,11 +103,11 @@ class TestAuthStrategy:
 
     def test_get_refresh_callback_calls_refresh_when_invoked(self) -> None:
         """Test that the callback returned by get_refresh_callback calls refresh."""
-        mock_callable = Mock()
+        mock_callable = MockClass()
         strategy = RefreshableAuthStrategy(http_request_callable=mock_callable)
 
         # Create a mock for the refresh method
-        refresh_mock = Mock(
+        refresh_mock = MockClass(
             return_value={
                 "token_data": {
                     "access_token": "new-token",
@@ -132,7 +133,7 @@ class TestAuthStrategy:
 
     def test_refreshable_strategy_can_refresh_with_http_callable(self) -> None:
         """Test that RefreshableAuthStrategy can refresh when http_request_callable is provided."""
-        mock_callable = Mock()
+        mock_callable = MockClass()
         strategy = RefreshableAuthStrategy(http_request_callable=mock_callable)
         assert strategy.can_refresh() is True
 
@@ -143,7 +144,7 @@ class TestAuthStrategy:
 
     def test_refreshable_strategy_refresh_returns_token_data(self) -> None:
         """Test that RefreshableAuthStrategy.refresh returns expected token data."""
-        mock_callable = Mock()
+        mock_callable = MockClass()
         strategy = RefreshableAuthStrategy(http_request_callable=mock_callable)
 
         result = strategy.refresh()

--- a/tests/unit/exceptions/test_auth_exceptions.py
+++ b/tests/unit/exceptions/test_auth_exceptions.py
@@ -1,6 +1,6 @@
 """Unit tests for authentication exception classes."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock as MockClass
 
 import pytest
 
@@ -33,7 +33,7 @@ class TestAuthenticationError:
 
     def test_initialization_with_request_object(self) -> None:
         """Test initialization with request object."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://api.example.com/token"
 
@@ -45,7 +45,7 @@ class TestAuthenticationError:
 
     def test_initialization_with_response_object(self) -> None:
         """Test initialization with response object."""
-        response = Mock(spec=["status_code", "reason", "headers", "text"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text"])
         response.status_code = 401
         response.reason = "Unauthorized"
         response.headers = {}
@@ -59,11 +59,11 @@ class TestAuthenticationError:
 
     def test_initialization_with_both_objects(self) -> None:
         """Test initialization with both request and response objects."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://api.example.com/token"
 
-        response = Mock(spec=["status_code", "reason", "headers", "text", "request"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text", "request"])
         response.status_code = 401
         response.reason = "Unauthorized"
         response.headers = {}
@@ -85,7 +85,7 @@ class TestAuthenticationError:
 
     def test_str_with_request_context_only(self) -> None:
         """Test string representation with request context only."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://api.example.com/token"
 
@@ -95,7 +95,7 @@ class TestAuthenticationError:
 
     def test_str_with_response_context_only(self) -> None:
         """Test string representation with response context only."""
-        response = Mock(spec=["status_code", "reason", "headers", "text"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text"])
         response.status_code = 401
         response.reason = "Unauthorized"
         response.headers = {}
@@ -107,11 +107,11 @@ class TestAuthenticationError:
 
     def test_str_with_both_contexts(self) -> None:
         """Test string representation with both contexts."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://api.example.com/token"
 
-        response = Mock(spec=["status_code", "reason", "headers", "text", "request"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text", "request"])
         response.status_code = 401
         response.reason = "Unauthorized"
         response.headers = {}
@@ -124,7 +124,7 @@ class TestAuthenticationError:
 
     def test_str_with_partial_request_context(self) -> None:
         """Test string representation with partial request context."""
-        request = Mock(spec=["method"])
+        request = MockClass(spec=["method"])
         request.method = "POST"
         # Missing URL attribute
 
@@ -134,7 +134,7 @@ class TestAuthenticationError:
 
     def test_str_with_partial_response_context(self) -> None:
         """Test string representation with partial response context."""
-        response = Mock(spec=["status_code", "headers", "text"])
+        response = MockClass(spec=["status_code", "headers", "text"])
         response.status_code = 401
         response.headers = {}
         response.text = ""
@@ -146,8 +146,8 @@ class TestAuthenticationError:
 
     def test_str_with_empty_contexts(self) -> None:
         """Test string representation with empty contexts."""
-        request = Mock(spec=[])  # No attributes
-        response = Mock(spec=[])  # No attributes
+        request = MockClass(spec=[])  # No attributes
+        response = MockClass(spec=[])  # No attributes
 
         error = AuthenticationError(
             "Auth failed",
@@ -180,11 +180,11 @@ class TestExpiredTokenError:
 
     def test_with_context(self) -> None:
         """Test with HTTP context."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "GET"
         request.url = "https://api.example.com/data"
 
-        response = Mock(spec=["status_code", "reason", "headers", "text", "request"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text", "request"])
         response.status_code = 401
         response.reason = "Token Expired"
         response.headers = {}
@@ -216,11 +216,11 @@ class TestTokenRefreshError:
 
     def test_with_context(self) -> None:
         """Test with HTTP context."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://api.example.com/oauth/token"
 
-        response = Mock(spec=["status_code", "reason", "headers", "text", "request"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text", "request"])
         response.status_code = 400
         response.reason = "Bad Request"
         response.headers = {}
@@ -252,11 +252,11 @@ class TestAuthStrategyError:
 
     def test_with_context(self) -> None:
         """Test with HTTP context."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://api.example.com/auth"
 
-        response = Mock(spec=["status_code", "reason", "headers", "text", "request"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text", "request"])
         response.status_code = 500
         response.reason = "Internal Server Error"
         response.headers = {}
@@ -288,11 +288,11 @@ class TestInvalidCredentialsError:
 
     def test_with_context(self) -> None:
         """Test with HTTP context."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://api.example.com/login"
 
-        response = Mock(spec=["status_code", "reason", "headers", "text", "request"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text", "request"])
         response.status_code = 401
         response.reason = "Unauthorized"
         response.headers = {}
@@ -324,11 +324,11 @@ class TestMissingCredentialsError:
 
     def test_with_context(self) -> None:
         """Test with HTTP context."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "GET"
         request.url = "https://api.example.com/protected"
 
-        response = Mock(spec=["status_code", "reason", "headers", "text", "request"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text", "request"])
         response.status_code = 401
         response.reason = "Unauthorized"
         response.headers = {}
@@ -360,11 +360,11 @@ class TestTokenRefreshJsonError:
 
     def test_with_context(self) -> None:
         """Test with HTTP context."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://api.example.com/oauth/token"
 
-        response = Mock(spec=["status_code", "reason", "headers", "text", "request"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text", "request"])
         response.status_code = 200
         response.reason = "OK"
         response.headers = {}
@@ -397,7 +397,7 @@ class TestTokenRefreshTimeoutError:
 
     def test_with_context(self) -> None:
         """Test with HTTP context."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://api.example.com/oauth/token"
 
@@ -427,7 +427,7 @@ class TestTokenRefreshNetworkError:
 
     def test_with_context(self) -> None:
         """Test with HTTP context."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://api.example.com/oauth/token"
 
@@ -493,11 +493,11 @@ class TestContextEdgeCases:
 
     def test_none_values_in_context(self) -> None:
         """Test handling of None values in context dictionaries."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = None  # None value
 
-        response = Mock(spec=["status_code", "reason", "headers", "text", "request"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text", "request"])
         response.status_code = None  # None value
         response.reason = "OK"
         response.headers = {}
@@ -511,8 +511,8 @@ class TestContextEdgeCases:
 
     def test_missing_keys_in_context(self) -> None:
         """Test handling when expected keys are missing from context."""
-        request = Mock(spec=[])  # Empty context - no attributes
-        response = Mock(spec=[])  # Empty context - no attributes
+        request = MockClass(spec=[])  # Empty context - no attributes
+        response = MockClass(spec=[])  # Empty context - no attributes
 
         error = AuthenticationError("Test error", request=request, response=response)
         # Empty contexts should not add context information
@@ -521,10 +521,10 @@ class TestContextEdgeCases:
 
     def test_context_with_unknown_values(self) -> None:
         """Test handling when context has keys but with None/missing values."""
-        request = Mock(spec=["method"])  # Has method but no url
+        request = MockClass(spec=["method"])  # Has method but no url
         request.method = "POST"
 
-        response = Mock(spec=["status_code", "headers", "text"])  # Has status_code but no reason
+        response = MockClass(spec=["status_code", "headers", "text"])  # Has status_code but no reason
         response.status_code = 401
         response.headers = {}
         response.text = ""
@@ -536,12 +536,12 @@ class TestContextEdgeCases:
 
     def test_extra_keys_in_context(self) -> None:
         """Test that extra keys in context don't break functionality."""
-        request = Mock(spec=["method", "url", "extra_field"])
+        request = MockClass(spec=["method", "url", "extra_field"])
         request.method = "POST"
         request.url = "https://api.example.com/token"
         request.extra_field = "should_be_ignored"
 
-        response = Mock(spec=["status_code", "reason", "headers", "text", "request", "extra_field"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text", "request", "extra_field"])
         response.status_code = 401
         response.reason = "Unauthorized"
         response.headers = {}

--- a/tests/unit/exceptions/test_http_exceptions.py
+++ b/tests/unit/exceptions/test_http_exceptions.py
@@ -1,6 +1,6 @@
 """Unit tests for HTTP exception classes."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock as MockClass
 
 from apiconfig.exceptions.base import APIConfigError, AuthenticationError
 from apiconfig.exceptions.http import (
@@ -39,7 +39,7 @@ class TestApiClientError:
 
     def test_initialization_with_request_object(self) -> None:
         """Test initialization with request object."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "GET"
         request.url = "https://api.example.com/users"
 
@@ -51,7 +51,7 @@ class TestApiClientError:
 
     def test_initialization_with_full_context(self) -> None:
         """Test initialization with both status code and request object."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://api.example.com/users"
 
@@ -64,12 +64,12 @@ class TestApiClientError:
     def test_initialization_with_response_object(self) -> None:
         """Test initialization with response object that includes request."""
         # Create mock request
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "DELETE"
         request.url = "https://api.example.com/item/123"
 
         # Create mock response with request
-        response = Mock(spec=["status_code", "reason", "request", "headers", "text"])
+        response = MockClass(spec=["status_code", "reason", "request", "headers", "text"])
         response.status_code = 404
         response.reason = "Not Found"
         response.request = request
@@ -88,7 +88,7 @@ class TestApiClientError:
     def test_str_with_partial_request_object(self) -> None:
         """Test string representation with partial request object."""
         # Only method
-        request = Mock(spec=["method"])
+        request = MockClass(spec=["method"])
         request.method = "GET"
 
         error = ApiClientError("Test error", request=request)
@@ -97,7 +97,7 @@ class TestApiClientError:
         assert error.url is None
 
         # Only URL
-        request = Mock(spec=["url"])
+        request = MockClass(spec=["url"])
         request.url = "https://api.example.com/users"
 
         error = ApiClientError("Test error", request=request)
@@ -107,7 +107,7 @@ class TestApiClientError:
 
     def test_str_with_empty_request_object(self) -> None:
         """Test string representation with empty request object."""
-        request = Mock(spec=[])  # No attributes
+        request = MockClass(spec=[])  # No attributes
         error = ApiClientError("Test error", request=request)
         assert str(error) == "Test error"
         assert error.method is None
@@ -137,7 +137,7 @@ class TestApiClientBadRequestError:
 
     def test_with_context(self) -> None:
         """Test initialization with context."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://api.example.com/users"
 
@@ -177,11 +177,11 @@ class TestApiClientUnauthorizedError:
 
     def test_with_context(self) -> None:
         """Test initialization with context."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "GET"
         request.url = "https://api.example.com/protected"
 
-        response = Mock(spec=["status_code", "reason", "headers", "text", "request"])
+        response = MockClass(spec=["status_code", "reason", "headers", "text", "request"])
         response.status_code = 401
         response.reason = "Unauthorized"
         response.headers = {}
@@ -199,7 +199,7 @@ class TestApiClientUnauthorizedError:
 
     def test_both_parent_init_called(self) -> None:
         """Test that both parent __init__ methods are called properly."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "GET"
         request.url = "https://api.example.com/test"
 
@@ -224,12 +224,12 @@ class TestApiClientUnauthorizedError:
         assert str(error) == "Test message (HTTP 401)"
 
         # Test with empty request object
-        empty_request = Mock(spec=[])
+        empty_request = MockClass(spec=[])
         error_empty_context = ApiClientUnauthorizedError("Test message", request=empty_request)
         assert str(error_empty_context) == "Test message (HTTP 401)"
 
         # Test with response but no request - should still get status from response
-        response = Mock(spec=["status_code", "headers", "text"])
+        response = MockClass(spec=["status_code", "headers", "text"])
         response.status_code = 401
         response.headers = {}
         response.text = ""
@@ -418,11 +418,11 @@ class TestCreateApiClientError:
 
     def test_with_context(self) -> None:
         """Test creation with request and response objects."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "GET"
         request.url = "https://api.example.com/users"
 
-        response = Mock(spec=["status_code", "reason", "request", "headers", "text"])
+        response = MockClass(spec=["status_code", "reason", "request", "headers", "text"])
         response.status_code = 404
         response.reason = "Not Found"
         response.request = request
@@ -504,12 +504,12 @@ class TestHttpExceptionIntegration:
 
     def test_context_preservation_through_factory(self) -> None:
         """Test that context is preserved when using the factory function."""
-        request = Mock(spec=["method", "url", "headers"])
+        request = MockClass(spec=["method", "url", "headers"])
         request.method = "POST"
         request.url = "https://api.example.com/users"
         request.headers = {"Content-Type": "application/json"}
 
-        response = Mock(spec=["status_code", "headers", "text", "reason", "request"])
+        response = MockClass(spec=["status_code", "headers", "text", "reason", "request"])
         response.status_code = 422
         response.headers = {"Content-Type": "application/json"}
         response.text = '{"error": "validation failed"}'

--- a/tests/unit/test_exception_protocols.py
+++ b/tests/unit/test_exception_protocols.py
@@ -1,7 +1,7 @@
 """Unit tests for HTTP exception protocol support."""
 
 from typing import Any, cast
-from unittest.mock import Mock
+from unittest.mock import Mock as MockClass
 
 import pytest
 
@@ -92,7 +92,7 @@ class TestProtocolExtraction:
 
     def test_extraction_with_none_values(self) -> None:
         """Test extraction handles None values gracefully."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = None
         request.url = None
 
@@ -108,7 +108,7 @@ class TestProtocolExtraction:
             def __str__(self) -> str:
                 return "https://custom.url"
 
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = 1  # Non-string
         request.url = CustomURL()  # Object with __str__
 
@@ -118,7 +118,7 @@ class TestProtocolExtraction:
 
     def test_response_without_request_attribute(self) -> None:
         """Test response objects that don't have a request attribute."""
-        response = Mock(spec=["status_code", "headers", "text", "reason"])
+        response = MockClass(spec=["status_code", "headers", "text", "reason"])
         response.status_code = 500
         response.headers = {}
         response.text = "Internal error"
@@ -135,7 +135,7 @@ class TestProtocolExtraction:
 
     def test_response_with_none_request(self) -> None:
         """Test response with request attribute set to None."""
-        response = Mock(spec=["status_code", "headers", "text", "reason", "request"])
+        response = MockClass(spec=["status_code", "headers", "text", "reason", "request"])
         response.status_code = 400
         response.headers = {}
         response.text = "Bad request"
@@ -153,11 +153,11 @@ class TestFactoryFunctionWithProtocols:
 
     def test_factory_with_response_object(self) -> None:
         """Test factory function with protocol-compliant response."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "DELETE"
         request.url = "https://api.example.com/item/456"
 
-        response = Mock(spec=["status_code", "headers", "text", "reason", "request"])
+        response = MockClass(spec=["status_code", "headers", "text", "reason", "request"])
         response.status_code = 404
         response.headers = {}
         response.text = "Item not found"
@@ -172,11 +172,11 @@ class TestFactoryFunctionWithProtocols:
 
     def test_factory_with_separate_request_response(self) -> None:
         """Test factory with both request and response objects."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "PATCH"
         request.url = "https://api.example.com/user/789"
 
-        response = Mock(spec=["status_code", "headers", "text", "reason"])
+        response = MockClass(spec=["status_code", "headers", "text", "reason"])
         response.status_code = 422
         response.headers = {}
         response.text = "Validation error"
@@ -195,7 +195,7 @@ class TestAuthExceptionsWithProtocols:
 
     def test_auth_error_with_response(self) -> None:
         """Test AuthenticationError with response object."""
-        response = Mock(spec=["status_code", "headers", "text", "reason"])
+        response = MockClass(spec=["status_code", "headers", "text", "reason"])
         response.status_code = 401
         response.headers = {"WWW-Authenticate": "Bearer"}
         response.text = "Invalid token"
@@ -208,11 +208,11 @@ class TestAuthExceptionsWithProtocols:
 
     def test_token_refresh_error_with_full_context(self) -> None:
         """Test TokenRefreshError with full HTTP context."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "POST"
         request.url = "https://auth.example.com/token/refresh"
 
-        response = Mock(spec=["status_code", "headers", "text", "reason", "request"])
+        response = MockClass(spec=["status_code", "headers", "text", "reason", "request"])
         response.status_code = 400
         response.headers = {"Content-Type": "application/json"}
         response.text = '{"error": "invalid_refresh_token"}'
@@ -252,11 +252,11 @@ class TestEdgeCases:
 
     def test_circular_reference(self) -> None:
         """Test handling of circular references between request and response."""
-        request = Mock(spec=["method", "url"])
+        request = MockClass(spec=["method", "url"])
         request.method = "GET"
         request.url = "https://api.example.com/data"
 
-        response = Mock(spec=["status_code", "headers", "text", "reason", "request"])
+        response = MockClass(spec=["status_code", "headers", "text", "reason", "request"])
         response.status_code = 200
         response.headers = {}
         response.text = "OK"


### PR DESCRIPTION
## Summary
- alias `Mock` imports in tests to `MockClass`
- update usages to avoid shadowing

## Testing
- `pre-commit run --files tests/component/test_auth_refresh_interface.py tests/component/test_auth_verification_integration.py tests/component/test_end_to_end_refresh.py tests/component/test_existing_component_integration.py tests/component/test_phase2_error_scenarios.py tests/component/test_refresh_error_handling.py tests/component/test_refresh_performance.py tests/unit/auth/strategies/test_bearer.py tests/unit/auth/strategies/test_custom.py tests/unit/auth/test_auth_base.py tests/unit/exceptions/test_auth_exceptions.py tests/unit/exceptions/test_http_exceptions.py tests/unit/test_exception_protocols.py`

------
https://chatgpt.com/codex/tasks/task_e_68699c83ccac8332b9235c488506f4de