### PR TITLE
Update DetailedFormatter import and defaults

### DIFF
--- a/apiconfig/utils/logging/formatters/detailed.py
+++ b/apiconfig/utils/logging/formatters/detailed.py
@@ -3,7 +3,7 @@
 
 import logging
 import textwrap
-import types
+import types as stdlib_types
 from typing import Any, Literal, Mapping, Optional
 
 
@@ -26,7 +26,12 @@ class DetailedFormatter(logging.Formatter):
         defaults: Optional[Mapping[str, Any]] = None,
     ) -> None:
         # Default format string
-        default_fmt = "%(asctime)s [%(levelname)-8s] [%(name)s] %(message)s" "\n    (%(filename)s:%(lineno)d)"
+        # fmt: off
+        default_fmt = (
+            "%(asctime)s [%(levelname)-8s] [%(name)s] %(message)s\n"
+            "    (%(filename)s:%(lineno)d)"
+        )
+        # fmt: on
         super().__init__(
             fmt=fmt or default_fmt,
             datefmt=datefmt,
@@ -77,7 +82,7 @@ class DetailedFormatter(logging.Formatter):
 
     def formatException(
         self,
-        ei: tuple[type[BaseException], BaseException, types.TracebackType | None] | tuple[None, None, None],
+        ei: tuple[type[BaseException], BaseException, stdlib_types.TracebackType | None] | tuple[None, None, None],
     ) -> str:
         """Format the specified exception information as a string.
 


### PR DESCRIPTION
## Summary
- tweak `DetailedFormatter`'s imports and default format string
- keep default format unformatted by Black

## Testing
- `poetry run pre-commit run --files apiconfig/utils/logging/formatters/detailed.py`
- `poetry run pytest tests/unit/utils/logging/formatters/test_detailed.py`


------
https://chatgpt.com/codex/tasks/task_e_68699c6d7a488332b84527c7091c71a3