### PR TITLE
Alias json module

### DIFF
--- a/apiconfig/types/__init__.py
+++ b/apiconfig/types/__init__.py
@@ -34,16 +34,20 @@ from .http import (
     ResponseBodyType,
     UrlencodeParamsType,
 )
-from .json import (
-    JsonDecoder,
-    JsonDeserializerCallable,
-    JsonEncoder,
-    JsonList,
-    JsonObject,
-    JsonPrimitive,
-    JsonSerializerCallable,
-    JsonValue,
-)
+
+# isort: off
+from . import json as json_types
+
+# isort: on
+
+JsonDecoder = json_types.JsonDecoder
+JsonDeserializerCallable = json_types.JsonDeserializerCallable
+JsonEncoder = json_types.JsonEncoder
+JsonList = json_types.JsonList
+JsonObject = json_types.JsonObject
+JsonPrimitive = json_types.JsonPrimitive
+JsonSerializerCallable = json_types.JsonSerializerCallable
+JsonValue = json_types.JsonValue
 
 __all__ = [
     # JSON types


### PR DESCRIPTION
## Summary
- alias the json submodule as `json_types`
- use the alias when re-exporting json-related types

## Testing
- `poetry run pre-commit run --files apiconfig/types/__init__.py`
- `poetry run pyright apiconfig/types/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68699c6ca1388332b3a2ed64c344a176