### PR TITLE
Fix integration server assertion message formatting

### DIFF
--- a/apiconfig/testing/integration/servers.py
+++ b/apiconfig/testing/integration/servers.py
@@ -199,8 +199,16 @@ def assert_request_received(
                 matching_requests.append(entry)
 
     if count is not None:
+        # fmt: off
         assert len(matching_requests) == count, (
-            f"Expected {count} request(s) matching criteria for {method} {path}, " f"but found {len(matching_requests)}. Log: {log}"
+            f"Expected {count} request(s) matching criteria for {method} {path}, "
+            f"but found {len(matching_requests)}. Log: {log}"
         )
+        # fmt: on
     else:
-        assert len(matching_requests) > 0, f"Expected at least one request matching criteria for {method} {path}, " f"but found none. Log: {log}"
+        # fmt: off
+        assert len(matching_requests) > 0, (
+            f"Expected at least one request matching criteria for {method} {path}, "
+            f"but found none. Log: {log}"
+        )
+        # fmt: on


### PR DESCRIPTION
## Summary
- clarify assert messages in integration test servers

## Testing
- `poetry run pre-commit run --files apiconfig/testing/integration/servers.py`
- `poetry run pytest tests/integration`


------
https://chatgpt.com/codex/tasks/task_e_68699c6bbedc83328fa4cc60e549e205