### PR TITLE
Fix bearer NotImplementedError message

### DIFF
--- a/apiconfig/auth/strategies/bearer.py
+++ b/apiconfig/auth/strategies/bearer.py
@@ -116,7 +116,8 @@ class BearerAuth(AuthStrategy):
         # This is a basic implementation that should be overridden by subclasses
         # or enhanced with specific refresh logic for the use case
         raise NotImplementedError(
-            "Bearer auth refresh requires custom implementation. " "Override this method or use a specialized auth strategy for your token type."
+            f"Bearer auth refresh requires custom implementation for {self.__class__.__name__}. "
+            "Override this method or use a specialized auth strategy for your token type."
         )
 
     def prepare_request_headers(self) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- join bearer auth NotImplementedError text into one f-string

## Testing
- `poetry run pre-commit run --files apiconfig/auth/strategies/bearer.py`
- `poetry run pytest tests/unit/auth`

------
https://chatgpt.com/codex/tasks/task_e_68699c6a899c8332a57b10b39cf36f70