### PR TITLE
Refactor logging imports

### DIFF
--- a/apiconfig/__init__.py
+++ b/apiconfig/__init__.py
@@ -8,7 +8,7 @@ strategies (Basic, Bearer, API Key, etc.).
 """
 
 import importlib.metadata
-import logging
+import logging as logging_mod
 
 # Core components re-exported for easier access
 from .auth.base import AuthStrategy
@@ -88,4 +88,4 @@ __all__: list[str] = [
 ]
 
 # Configure null handler for library logging
-logging.getLogger(__name__).addHandler(logging.NullHandler())
+logging_mod.getLogger(__name__).addHandler(logging_mod.NullHandler())

--- a/apiconfig/auth/strategies/basic.py
+++ b/apiconfig/auth/strategies/basic.py
@@ -5,14 +5,14 @@ credentials (base64-encoded username:password) to HTTP requests.
 """
 
 import base64
-import logging
+import logging as logging_mod
 from typing import Dict, Optional
 
 from apiconfig.auth.base import AuthStrategy
 from apiconfig.exceptions.auth import AuthStrategyError
 from apiconfig.types import QueryParamType
 
-log: logging.Logger = logging.getLogger(__name__)
+log: logging_mod.Logger = logging_mod.getLogger(__name__)
 
 
 class BasicAuth(AuthStrategy):

--- a/apiconfig/auth/strategies/bearer.py
+++ b/apiconfig/auth/strategies/bearer.py
@@ -1,6 +1,6 @@
 """Implements Bearer Token authentication strategy."""
 
-import logging
+import logging as logging_mod
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
 
@@ -12,7 +12,7 @@ from apiconfig.types import (
     TokenRefreshResult,
 )
 
-log = logging.getLogger(__name__)
+log = logging_mod.getLogger(__name__)
 
 
 class BearerAuth(AuthStrategy):

--- a/apiconfig/auth/token/refresh.py
+++ b/apiconfig/auth/token/refresh.py
@@ -7,7 +7,7 @@ It includes retry logic for transient errors.
 """
 
 import json
-import logging
+import logging as logging_mod
 import time
 
 # Import httpx only for type annotations, not for actual use
@@ -26,7 +26,7 @@ from ...exceptions.auth import (
 )
 
 # Set up logging
-logger = logging.getLogger(__name__)
+logger = logging_mod.getLogger(__name__)
 
 
 class OAuthTokenData(TypedDict, total=False):

--- a/apiconfig/config/base.py
+++ b/apiconfig/config/base.py
@@ -6,7 +6,7 @@ like hostname, version, headers, timeout, retries, and authentication.
 """
 
 import copy
-import logging
+import logging as logging_mod
 import warnings
 from typing import TYPE_CHECKING, Dict, Optional, TypeVar
 from urllib.parse import urljoin
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from apiconfig.auth.base import AuthStrategy  # noqa: F401 - Used for type hinting
 
 # Set up logging
-logger = logging.getLogger(__name__)
+logger = logging_mod.getLogger(__name__)
 
 
 _TClientConfig = TypeVar("_TClientConfig", bound="ClientConfig")

--- a/apiconfig/config/manager.py
+++ b/apiconfig/config/manager.py
@@ -1,6 +1,6 @@
 """Manages loading configuration from multiple providers."""
 
-import logging
+import logging as logging_mod
 from typing import (
     Any,
     Dict,
@@ -33,7 +33,7 @@ class _SupportsGetConfig(Protocol[_TConfig]):
 
 ConfigProvider: TypeAlias = _SupportsLoad[Mapping[str, Any]] | _SupportsGetConfig[Mapping[str, Any]]
 
-logger: logging.Logger = logging.getLogger(__name__)
+logger: logging_mod.Logger = logging_mod.getLogger(__name__)
 
 
 class ConfigManager:

--- a/apiconfig/types/extensions.py
+++ b/apiconfig/types/extensions.py
@@ -1,13 +1,13 @@
 """Extension-related type definitions."""
 
-import logging
+import logging as logging_mod
 from typing import Any, Callable, TypeAlias
 
 # Extension Types
-CustomLogFormatter: TypeAlias = logging.Formatter
+CustomLogFormatter: TypeAlias = logging_mod.Formatter
 """Type alias for custom log formatter instances."""
 
-CustomLogHandler: TypeAlias = logging.Handler
+CustomLogHandler: TypeAlias = logging_mod.Handler
 """Type alias for custom log handler instances."""
 
 CustomRedactionRule: TypeAlias = Callable[[str], str]

--- a/apiconfig/utils/logging/filters.py
+++ b/apiconfig/utils/logging/filters.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 """Logging filters, including context injection."""
 
-import logging
+import logging as logging_mod
 import threading
 from typing import Any
 
 _log_context = threading.local()
 
 
-class ContextFilter(logging.Filter):
+class ContextFilter(logging_mod.Filter):
     """Inject context variables from thread-local storage into log records.
 
     Usage
@@ -21,13 +21,13 @@ class ContextFilter(logging.Filter):
 
     Example Formatter Usage
     -----------------------
-    formatter = logging.Formatter(
+    formatter = logging_mod.Formatter(
         '%(asctime)s - %(name)s - %(levelname)s - [%(request_id)s] - %(message)s'
     )
     # Assuming 'request_id' was set using set_log_context('request_id', ...)
     """
 
-    def filter(self, record: logging.LogRecord) -> bool:
+    def filter(self, record: logging_mod.LogRecord) -> bool:
         """Add context variables from thread-local storage to the log record.
 
         Args

--- a/apiconfig/utils/logging/formatters/detailed.py
+++ b/apiconfig/utils/logging/formatters/detailed.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 """Detailed logging formatter."""
 
-import logging
+import logging as logging_mod
 import textwrap
 import types
 from typing import Any, Literal, Mapping, Optional
 
 
-class DetailedFormatter(logging.Formatter):
+class DetailedFormatter(logging_mod.Formatter):
     """
     A logging formatter that provides detailed, potentially multi-line output.
 
@@ -35,7 +35,7 @@ class DetailedFormatter(logging.Formatter):
             defaults=defaults,
         )
 
-    def format(self, record: logging.LogRecord) -> str:
+    def format(self, record: logging_mod.LogRecord) -> str:
         """Format the specified record as text.
 
         Handles multi-line messages, exception text, and stack information.
@@ -58,7 +58,7 @@ class DetailedFormatter(logging.Formatter):
         formatted = self._format_stack_info(formatted, record)
         return formatted
 
-    def _format_multiline_message(self, formatted: str, record: logging.LogRecord) -> str:
+    def _format_multiline_message(self, formatted: str, record: logging_mod.LogRecord) -> str:
         lines = formatted.split("\n")
         if len(lines) <= 1:
             return formatted
@@ -112,7 +112,7 @@ class DetailedFormatter(logging.Formatter):
         """
         return super().formatStack(stack_info)
 
-    def _format_exception_text(self, formatted: str, record: logging.LogRecord) -> str:
+    def _format_exception_text(self, formatted: str, record: logging_mod.LogRecord) -> str:
         if record.exc_info and not getattr(record, "exc_text", None):
             record.exc_text = self.formatException(record.exc_info)
         if getattr(record, "exc_text", None):
@@ -122,7 +122,7 @@ class DetailedFormatter(logging.Formatter):
             formatted += exc_text
         return formatted
 
-    def _format_stack_info(self, formatted: str, record: logging.LogRecord) -> str:
+    def _format_stack_info(self, formatted: str, record: logging_mod.LogRecord) -> str:
         if record.stack_info:
             stack_info = textwrap.indent(self.formatStack(record.stack_info), "    ")
             if formatted[-1:] != "\n":

--- a/apiconfig/utils/logging/formatters/redacting.py
+++ b/apiconfig/utils/logging/formatters/redacting.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-import logging
+import logging as logging_mod
 import re
 from typing import Any, Literal, Mapping, Optional, Set, Tuple
 
@@ -24,7 +24,7 @@ from apiconfig.utils.redaction.headers import (
 from .detailed import DetailedFormatter
 
 
-class RedactingFormatter(logging.Formatter):
+class RedactingFormatter(logging_mod.Formatter):
     """Automatically redact sensitive information from log messages and HTTP headers.
 
     Guarantees
@@ -113,7 +113,7 @@ class RedactingFormatter(logging.Formatter):
         self._redact_body = redact_body
         self._redact_headers_func = redact_headers
 
-    def format(self, record: logging.LogRecord) -> str:
+    def format(self, record: logging_mod.LogRecord) -> str:
         """Format the specified record as text, redacting sensitive data.
 
         Args
@@ -130,7 +130,7 @@ class RedactingFormatter(logging.Formatter):
         self._redact_message(record)
         return super().format(record)
 
-    def _redact_headers(self, record: logging.LogRecord) -> None:
+    def _redact_headers(self, record: logging_mod.LogRecord) -> None:
         headers: Mapping[str, str] | None = getattr(record, "headers", None)
         if headers is not None:
             try:
@@ -145,7 +145,7 @@ class RedactingFormatter(logging.Formatter):
             except Exception:
                 pass
 
-    def _redact_message(self, record: logging.LogRecord) -> None:
+    def _redact_message(self, record: logging_mod.LogRecord) -> None:
         """Redact the log message in-place on the record.
 
         Handles all input types robustly:
@@ -279,7 +279,7 @@ def redact_structured_helper(formatter: RedactingFormatter, msg: Any, content_ty
     return formatter._redact_structured(msg, content_type)  # pyright: ignore[reportPrivateUsage]
 
 
-def redact_message_helper(formatter: RedactingFormatter, record: logging.LogRecord) -> None:
+def redact_message_helper(formatter: RedactingFormatter, record: logging_mod.LogRecord) -> None:
     """Public helper to call ``RedactingFormatter._redact_message`` for tests."""
     formatter._redact_message(record)  # pyright: ignore[reportPrivateUsage]
 
@@ -287,7 +287,7 @@ def redact_message_helper(formatter: RedactingFormatter, record: logging.LogReco
 def format_exception_text_helper(
     formatter: DetailedFormatter,
     formatted: str,
-    record: logging.LogRecord,
+    record: logging_mod.LogRecord,
 ) -> str:
     """Public helper to call ``DetailedFormatter._format_exception_text`` for tests."""
     return formatter._format_exception_text(formatted, record)  # pyright: ignore[reportPrivateUsage]
@@ -296,7 +296,7 @@ def format_exception_text_helper(
 def format_stack_info_helper(
     formatter: DetailedFormatter,
     formatted: str,
-    record: logging.LogRecord,
+    record: logging_mod.LogRecord,
 ) -> str:
     """Public helper to call ``DetailedFormatter._format_stack_info`` for tests."""
     return formatter._format_stack_info(formatted, record)  # pyright: ignore[reportPrivateUsage]

--- a/apiconfig/utils/logging/handlers.py
+++ b/apiconfig/utils/logging/handlers.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
-import logging
+import logging as logging_mod
 import sys
 from typing import IO, Optional
 
-_StreamHandlerBase = logging.StreamHandler[IO[str]]
+_StreamHandlerBase = logging_mod.StreamHandler[IO[str]]
 
 
 class ConsoleHandler(_StreamHandlerBase):

--- a/apiconfig/utils/logging/setup.py
+++ b/apiconfig/utils/logging/setup.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 """Logging setup utilities for the apiconfig library."""
 
-import logging
+import logging as logging_mod
 import sys
 from typing import List, Optional, Union
 
 from .formatters import RedactingFormatter
 from .handlers import RedactingStreamHandler
 
-_logger: logging.Logger = logging.getLogger("apiconfig")
+_logger: logging_mod.Logger = logging_mod.getLogger("apiconfig")
 
 
 def setup_logging(
-    level: Union[int, str] = logging.WARNING,
-    handlers: Optional[List[logging.Handler]] = None,
-    formatter: Optional[logging.Formatter] = None,
+    level: Union[int, str] = logging_mod.WARNING,
+    handlers: Optional[List[logging_mod.Handler]] = None,
+    formatter: Optional[logging_mod.Formatter] = None,
 ) -> None:
     """Configure logging for the apiconfig library.
 

--- a/helpers_for_tests/tripletex/tripletex_auth.py
+++ b/helpers_for_tests/tripletex/tripletex_auth.py
@@ -2,7 +2,7 @@
 
 import base64
 import json
-import logging
+import logging as logging_mod
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -198,7 +198,7 @@ class TripletexSessionAuth(AuthStrategy):
 
     def refresh(self) -> Optional[TokenRefreshResult]:
         """Refresh the session token using consumer/employee tokens."""
-        logger = logging.getLogger(__name__)
+        logger = logging_mod.getLogger(__name__)
         logger.debug("Starting token refresh")
 
         if not self.can_refresh():

--- a/tests/component/test_existing_component_integration.py
+++ b/tests/component/test_existing_component_integration.py
@@ -1,6 +1,6 @@
 """Test integration with existing apiconfig components."""
 
-import logging
+import logging as logging_mod
 from io import StringIO
 from typing import Any, Dict
 from unittest.mock import Mock
@@ -71,10 +71,10 @@ class TestExistingComponentIntegration:
         """Test integration with logging system."""
         # Capture log output
         log_capture = StringIO()
-        handler = logging.StreamHandler(log_capture)
-        logger = logging.getLogger("apiconfig")
+        handler = logging_mod.StreamHandler(log_capture)
+        logger = logging_mod.getLogger("apiconfig")
         logger.addHandler(handler)
-        logger.setLevel(logging.INFO)
+        logger.setLevel(logging_mod.INFO)
 
         try:
             mock_http = Mock()

--- a/tests/integration/test_logging_redacting_formatter.py
+++ b/tests/integration/test_logging_redacting_formatter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-import logging
+import logging as logging_mod
 import re
 from typing import Any, Generator, Protocol, cast
 
@@ -17,13 +17,13 @@ def log_stream() -> Generator[io.StringIO, None, None]:
     stream.close()
 
 
-def get_logger_with_formatter(stream: io.StringIO, **fmt_kwargs: Any) -> logging.Logger:
-    logger = logging.getLogger("integration.redact")
+def get_logger_with_formatter(stream: io.StringIO, **fmt_kwargs: Any) -> logging_mod.Logger:
+    logger = logging_mod.getLogger("integration.redact")
     logger.handlers.clear()
-    handler = logging.StreamHandler(stream)
+    handler = logging_mod.StreamHandler(stream)
     handler.setFormatter(RedactingFormatter(**fmt_kwargs))
     logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logging_mod.INFO)
     return logger
 
 
@@ -71,9 +71,9 @@ def test_redacting_formatter_integration_headers(log_stream: io.StringIO) -> Non
     # For integration, we check that the record's headers are redacted
     # (This is a limitation of logging, but we can at least check the handler's formatter)
     # So we check that the handler's formatter redacts headers
-    record = logging.LogRecord(
+    record = logging_mod.LogRecord(
         name="integration.redact",
-        level=logging.INFO,
+        level=logging_mod.INFO,
         pathname=__file__,
         lineno=1,
         msg="header test",
@@ -92,7 +92,7 @@ def test_redacting_formatter_integration_headers(log_stream: io.StringIO) -> Non
     class TypedLogRecord(Protocol):
         headers: dict[str, str]
 
-    handler = logging.StreamHandler(io.StringIO())
+    handler = logging_mod.StreamHandler(io.StringIO())
     handler.setFormatter(RedactingFormatter())
     handler.format(record)
     # Use cast only for attribute access
@@ -107,9 +107,9 @@ def test_redacting_formatter_integration_cookie_header(log_stream: io.StringIO) 
     _ = get_logger_with_formatter(log_stream)
 
     # Create a record with a Cookie header
-    record = logging.LogRecord(
+    record = logging_mod.LogRecord(
         name="integration.redact",
-        level=logging.INFO,
+        level=logging_mod.INFO,
         pathname=__file__,
         lineno=1,
         msg="cookie header test",
@@ -130,7 +130,7 @@ def test_redacting_formatter_integration_cookie_header(log_stream: io.StringIO) 
         headers: dict[str, str]
 
     # Format the record
-    handler = logging.StreamHandler(io.StringIO())
+    handler = logging_mod.StreamHandler(io.StringIO())
     handler.setFormatter(RedactingFormatter())
     handler.format(record)
 
@@ -148,9 +148,9 @@ def test_redacting_formatter_integration_set_cookie_header(
     _ = get_logger_with_formatter(log_stream)
 
     # Create a record with a Set-Cookie header
-    record = logging.LogRecord(
+    record = logging_mod.LogRecord(
         name="integration.redact",
-        level=logging.INFO,
+        level=logging_mod.INFO,
         pathname=__file__,
         lineno=1,
         msg="set-cookie header test",
@@ -171,7 +171,7 @@ def test_redacting_formatter_integration_set_cookie_header(
         headers: dict[str, str]
 
     # Format the record
-    handler = logging.StreamHandler(io.StringIO())
+    handler = logging_mod.StreamHandler(io.StringIO())
     handler.setFormatter(RedactingFormatter())
     handler.format(record)
 

--- a/tests/integration/test_tripletex_auth_refresh.py
+++ b/tests/integration/test_tripletex_auth_refresh.py
@@ -5,7 +5,7 @@ as a real-world example, validating the complete refresh flow from auth strategy
 successful API calls.
 """
 
-import logging
+import logging as logging_mod
 import os
 import threading
 from datetime import datetime, timedelta, timezone
@@ -173,7 +173,7 @@ class TestTripletexAuthRefresh:
         auth_strategy = tripletex_client.config.auth_strategy
         assert isinstance(auth_strategy, TripletexSessionAuth)
 
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging_mod.DEBUG):
             auth_strategy.refresh()
 
         # Verify refresh operation was logged (check for any log messages)

--- a/tests/unit/config/test_manager.py
+++ b/tests/unit/config/test_manager.py
@@ -1,6 +1,6 @@
 """Tests for the ConfigManager class."""
 
-import logging
+import logging as logging_mod
 from typing import Any, Dict, Optional, cast
 
 import pytest
@@ -169,7 +169,7 @@ class TestConfigManager:
 
     def test_load_config_logging(self, caplog: LogCaptureFixture) -> None:
         """Test that ConfigManager logs appropriate messages."""
-        caplog.set_level(logging.DEBUG)
+        caplog.set_level(logging_mod.DEBUG)
 
         provider1 = MockProvider(config_data={"api": {"hostname": "example1.com"}}, name="Provider1")
         provider2 = MockProvider(config_data={"api": {"hostname": "example2.com"}}, name="Provider2")
@@ -185,9 +185,9 @@ class TestConfigManager:
 
     def test_load_config_provider_returns_non_dict_value_warning(self, caplog: LogCaptureFixture) -> None:
         """Test loading config from a provider that returns a non-dict value logs a warning."""
-        import logging
+        import logging as logging_mod
 
-        caplog.set_level(logging.WARNING)
+        caplog.set_level(logging_mod.WARNING)
 
         # Create a provider that returns a non-dict value
         class BadProvider:

--- a/tests/unit/utils/logging/formatters/test_detailed.py
+++ b/tests/unit/utils/logging/formatters/test_detailed.py
@@ -1,4 +1,4 @@
-import logging
+import logging as logging_mod
 import sys
 import traceback
 from typing import Any, Callable
@@ -11,12 +11,12 @@ from apiconfig.utils.logging.formatters import (
 )
 
 
-class TypedLogRecord(logging.LogRecord):
+class TypedLogRecord(logging_mod.LogRecord):
     headers: dict[str, str]
 
 
 @pytest.fixture
-def log_record_factory() -> Callable[..., logging.LogRecord]:
+def log_record_factory() -> Callable[..., logging_mod.LogRecord]:
     """Factory for creating LogRecord objects with various parameters."""
 
     def make(
@@ -25,12 +25,12 @@ def log_record_factory() -> Callable[..., logging.LogRecord]:
         exc_info: Any = None,
         stack_info: Any = None,
         name: str = "test.logger",
-        level: int = logging.INFO,
+        level: int = logging_mod.INFO,
         pathname: str = __file__,
         lineno: int = 42,
         func: str | None = None,
-    ) -> logging.LogRecord:
-        record = logging.LogRecord(
+    ) -> logging_mod.LogRecord:
+        record = logging_mod.LogRecord(
             name=name,
             level=level,
             pathname=pathname,
@@ -53,7 +53,7 @@ def log_record_factory() -> Callable[..., logging.LogRecord]:
         ("multi\nline\nmessage", "multi\n"),
     ],
 )
-def test_detailed_formatter_basic_and_multiline(log_record_factory: Callable[..., logging.LogRecord], msg: str, expected_in: str) -> None:
+def test_detailed_formatter_basic_and_multiline(log_record_factory: Callable[..., logging_mod.LogRecord], msg: str, expected_in: str) -> None:
     fmt = DetailedFormatter()
     record = log_record_factory(msg=msg)
     output = fmt.format(record)
@@ -64,7 +64,7 @@ def test_detailed_formatter_basic_and_multiline(log_record_factory: Callable[...
 
 
 def test_detailed_formatter_custom_format(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     custom_fmt = "[%(levelname)s] %(message)s"
     fmt = DetailedFormatter(fmt=custom_fmt)
@@ -75,7 +75,7 @@ def test_detailed_formatter_custom_format(
 
 
 def test_detailed_formatter_indents_multiline_message(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     msg = "first line\nsecond line\nthird line"
     fmt = DetailedFormatter()
@@ -87,7 +87,7 @@ def test_detailed_formatter_indents_multiline_message(
 
 
 def test_detailed_formatter_with_exception(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = DetailedFormatter()
     try:
@@ -102,7 +102,7 @@ def test_detailed_formatter_with_exception(
 
 
 def test_detailed_formatter_with_stack_info(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = DetailedFormatter()
     stack = "".join(traceback.format_stack())
@@ -115,7 +115,7 @@ def test_detailed_formatter_with_stack_info(
 
 
 def test_detailed_formatter_with_exception_and_stack(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = DetailedFormatter()
     stack = "".join(traceback.format_stack())
@@ -134,7 +134,7 @@ def test_detailed_formatter_with_exception_and_stack(
 
 
 def test_detailed_formatter_exc_info_and_stack_full_branch(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = DetailedFormatter()
     stack = "".join(traceback.format_stack())
@@ -155,7 +155,7 @@ def test_detailed_formatter_exc_info_and_stack_full_branch(
 
 
 @pytest.mark.parametrize("style", ["%"])
-def test_detailed_formatter_style_variants(log_record_factory: Callable[..., logging.LogRecord], style: str) -> None:
+def test_detailed_formatter_style_variants(log_record_factory: Callable[..., logging_mod.LogRecord], style: str) -> None:
     from typing import Literal, cast
 
     fmt = DetailedFormatter(style=cast(Literal["%", "{", "$"], style))
@@ -165,7 +165,7 @@ def test_detailed_formatter_style_variants(log_record_factory: Callable[..., log
 
 
 def test_detailed_formatter_repr_and_str(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = DetailedFormatter()
     record = log_record_factory(msg="repr test")
@@ -174,7 +174,7 @@ def test_detailed_formatter_repr_and_str(
 
 
 def test_detailed_formatter_empty_message(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = DetailedFormatter()
     record = log_record_factory(msg="")
@@ -184,7 +184,7 @@ def test_detailed_formatter_empty_message(
 
 
 def test_detailed_formatter_metadata_len_minus_one(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     custom_fmt = "%(asctime)s [%(levelname)s] [%(name)s]\n%(message)s"
     fmt = DetailedFormatter(fmt=custom_fmt)
@@ -203,7 +203,7 @@ def test_detailed_formatter_metadata_len_minus_one(
 
 
 def test_detailed_formatter_exc_info_sets_exc_text(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = DetailedFormatter()
     try:
@@ -217,7 +217,7 @@ def test_detailed_formatter_exc_info_sets_exc_text(
 
 
 def test_detailed_formatter_exc_info_sets_exc_text_branch(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = DetailedFormatter()
     try:
@@ -232,7 +232,7 @@ def test_detailed_formatter_exc_info_sets_exc_text_branch(
 
 
 def test_detailed_formatter_format_exception_text_direct(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     """Test _format_exception_text via its public helper."""
     fmt = DetailedFormatter()

--- a/tests/unit/utils/logging/formatters/test_redacting.py
+++ b/tests/unit/utils/logging/formatters/test_redacting.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+import logging as logging_mod
 from typing import Any, Callable, cast
 
 import pytest
@@ -13,7 +13,7 @@ from apiconfig.utils.logging.formatters import (
 
 
 @pytest.fixture
-def log_record_factory() -> Callable[..., logging.LogRecord]:
+def log_record_factory() -> Callable[..., logging_mod.LogRecord]:
     """Factory for creating LogRecord objects with various parameters."""
 
     def make(
@@ -22,12 +22,12 @@ def log_record_factory() -> Callable[..., logging.LogRecord]:
         exc_info: Any = None,
         stack_info: Any = None,
         name: str = "test.logger",
-        level: int = logging.INFO,
+        level: int = logging_mod.INFO,
         pathname: str = __file__,
         lineno: int = 42,
         func: str | None = None,
-    ) -> logging.LogRecord:
-        record = logging.LogRecord(
+    ) -> logging_mod.LogRecord:
+        record = logging_mod.LogRecord(
             name=name,
             level=level,
             pathname=pathname,
@@ -54,11 +54,11 @@ def _always_false_structured(msg: Any, content_type: Any) -> bool:
 
 
 def test_redacting_formatter_basic(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = RedactingFormatter()
     record = log_record_factory(msg="redact test")
-    assert fmt.format(record) == logging.Formatter().format(record)
+    assert fmt.format(record) == logging_mod.Formatter().format(record)
 
 
 def test_redacting_formatter_class_and_docstring() -> None:
@@ -70,7 +70,7 @@ def test_redacting_formatter_class_and_docstring() -> None:
 
 
 def test_redacting_formatter_format(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = RedactingFormatter()
     record = log_record_factory(msg="redact format test")
@@ -100,7 +100,7 @@ def test_redacting_formatter_format(
     ],
 )
 def test_redacting_formatter_structured_redaction(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
     msg: Any,
     content_type: str | None,
     expected: str,
@@ -117,7 +117,7 @@ def test_redacting_formatter_structured_redaction(
 
 
 def test_redacting_formatter_headers_redaction(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = RedactingFormatter()
     record = log_record_factory(msg="headers test")
@@ -139,7 +139,7 @@ def test_redacting_formatter_headers_redaction(
 
 
 def test_redacting_formatter_plain_string_secret(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     import re
 
@@ -152,7 +152,7 @@ def test_redacting_formatter_plain_string_secret(
 
 
 def test_redacting_formatter_binary_and_unparsable(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = RedactingFormatter()
     record = log_record_factory(msg=b"\x00\x01\x02\x03")
@@ -166,7 +166,7 @@ def test_redacting_formatter_binary_and_unparsable(
 
 
 def test_redacting_formatter_empty_message(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = RedactingFormatter()
     record = log_record_factory(msg="")
@@ -176,7 +176,7 @@ def test_redacting_formatter_empty_message(
 
 
 def test_redacting_formatter_fallback_branch(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = RedactingFormatter()
 
@@ -191,7 +191,7 @@ def test_redacting_formatter_fallback_branch(
 
 def test_redacting_formatter_redact_headers_exception(
     monkeypatch: pytest.MonkeyPatch,
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = RedactingFormatter()
     record = log_record_factory(msg="headers test")
@@ -211,7 +211,7 @@ def test_redacting_formatter_redact_headers_exception(
 
 def test_redacting_formatter_redact_structured_exception(
     monkeypatch: pytest.MonkeyPatch,
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = RedactingFormatter()
     record = log_record_factory(msg={"foo": "bar"})
@@ -227,7 +227,7 @@ def test_redacting_formatter_redact_structured_exception(
 
 
 def test_redacting_formatter_structured_dict_list_coverage(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = RedactingFormatter()
     record = log_record_factory(msg={"secret": "abc", "foo": "bar"})
@@ -240,7 +240,7 @@ def test_redacting_formatter_structured_dict_list_coverage(
 
 def test_redacting_formatter_structured_string_json_exception(
     monkeypatch: pytest.MonkeyPatch,
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = RedactingFormatter()
     record = log_record_factory(msg='{"token": "abc"}')
@@ -256,7 +256,7 @@ def test_redacting_formatter_structured_string_json_exception(
 
 def test_redacting_formatter_structured_dict_exception(
     monkeypatch: pytest.MonkeyPatch,
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = RedactingFormatter()
     record = log_record_factory(msg={"token": "abc"})
@@ -270,7 +270,7 @@ def test_redacting_formatter_structured_dict_exception(
 
 
 def test_redacting_formatter_fallback_branch_strmsg(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     fmt = RedactingFormatter()
 
@@ -292,7 +292,7 @@ def test_redacting_formatter_is_structured_dict_list() -> None:
 
 def test_redacting_formatter_redact_structured_dict_from_string(
     monkeypatch: pytest.MonkeyPatch,
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     """Test that _redact_structured correctly handles dict return from redact_body."""
     fmt = RedactingFormatter()
@@ -376,7 +376,7 @@ def test_redacting_formatter_redact_structured_other_type_direct(
 
 def test_redacting_formatter_redact_message_dict_json_dumps_direct(
     monkeypatch: pytest.MonkeyPatch,
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     """Test that a dict message is converted to JSON in _redact_message."""
     fmt = RedactingFormatter()
@@ -410,7 +410,7 @@ def test_redacting_formatter_redact_message_dict_json_dumps_direct(
 
 
 def test_redacting_formatter_unknown_type_fallback_direct(
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test the fallback branch in _redact_message for unknown types."""
@@ -443,7 +443,7 @@ def test_redacting_formatter_unknown_type_fallback_direct(
 
 def test_redacting_formatter_redact_structured_string_exception_fallback(
     monkeypatch: pytest.MonkeyPatch,
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     """Test the exception fallback for string input in _redact_structured."""
     fmt = RedactingFormatter()
@@ -474,9 +474,9 @@ def test_redacting_formatter_line_138_direct(monkeypatch: pytest.MonkeyPatch) ->
     obj = NonStringNonDictNonList()
 
     # Create a record with our custom object
-    record = logging.LogRecord(
+    record = logging_mod.LogRecord(
         name="test.logger",
-        level=logging.INFO,
+        level=logging_mod.INFO,
         pathname=__file__,
         lineno=42,
         msg=obj,
@@ -563,7 +563,7 @@ def test_redacting_formatter_line_224_direct(monkeypatch: pytest.MonkeyPatch) ->
 
 def test_redacting_formatter_line_138_direct_with_format(
     monkeypatch: pytest.MonkeyPatch,
-    log_record_factory: Callable[..., logging.LogRecord],
+    log_record_factory: Callable[..., logging_mod.LogRecord],
 ) -> None:
     """Exercise _redact_message via format() with a custom object."""
     fmt = RedactingFormatter()
@@ -603,7 +603,7 @@ def test_redacting_formatter_line_138_with_subclass() -> None:
 
     # Create a subclass that overrides the necessary methods to force the fallback branch
     class TestRedactingFormatter(RedactingFormatter):
-        def _redact_message(self, record: logging.LogRecord) -> None:
+        def _redact_message(self, record: logging_mod.LogRecord) -> None:
             # Get the original message
             orig_msg = getattr(record, "msg", None)
 
@@ -625,9 +625,9 @@ def test_redacting_formatter_line_138_with_subclass() -> None:
     obj = TestObject()
 
     # Create a record with the custom object
-    record = logging.LogRecord(
+    record = logging_mod.LogRecord(
         name="test.logger",
-        level=logging.INFO,
+        level=logging_mod.INFO,
         pathname=__file__,
         lineno=42,
         msg=obj,

--- a/tests/unit/utils/logging/test_filters.py
+++ b/tests/unit/utils/logging/test_filters.py
@@ -1,4 +1,4 @@
-import logging
+import logging as logging_mod
 from typing import Any, Generator
 
 import pytest
@@ -20,9 +20,9 @@ def clear_context() -> Generator[None, None, None]:
 
 def test_set_log_context_sets_value() -> None:
     set_log_context("user_id", 123)
-    record = logging.LogRecord(
+    record = logging_mod.LogRecord(
         name="test",
-        level=logging.INFO,
+        level=logging_mod.INFO,
         pathname=__file__,
         lineno=1,
         msg="msg",
@@ -38,9 +38,9 @@ def test_clear_log_context_removes_all_keys() -> None:
     set_log_context("foo", "bar")
     set_log_context("baz", 42)
     clear_log_context()
-    record = logging.LogRecord(
+    record = logging_mod.LogRecord(
         name="test",
-        level=logging.INFO,
+        level=logging_mod.INFO,
         pathname=__file__,
         lineno=1,
         msg="msg",
@@ -65,9 +65,9 @@ def test_context_filter_filter_adds_context_to_record(context: dict[str, Any]) -
     clear_log_context()
     for k, v in context.items():
         set_log_context(k, v)
-    record = logging.LogRecord(
+    record = logging_mod.LogRecord(
         name="test",
-        level=logging.INFO,
+        level=logging_mod.INFO,
         pathname=__file__,
         lineno=1,
         msg="msg",
@@ -83,9 +83,9 @@ def test_context_filter_filter_adds_context_to_record(context: dict[str, Any]) -
 
 def test_context_filter_filter_no_context_does_not_fail() -> None:
     clear_log_context()
-    record = logging.LogRecord(
+    record = logging_mod.LogRecord(
         name="test",
-        level=logging.INFO,
+        level=logging_mod.INFO,
         pathname=__file__,
         lineno=1,
         msg="msg",

--- a/tests/unit/utils/logging/test_setup.py
+++ b/tests/unit/utils/logging/test_setup.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+import logging as logging_mod
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -11,7 +11,7 @@ from apiconfig.utils.logging.setup import setup_logging
 # but we patch the standard ones here to avoid import issues if those aren't implemented/exported yet
 # and to focus the test on the setup logic itself.
 DEFAULT_LOGGER_NAME = "apiconfig"
-DEFAULT_LOG_LEVEL = logging.WARNING  # Default level is WARNING as per .pyi
+DEFAULT_LOG_LEVEL = logging_mod.WARNING  # Default level is WARNING as per .pyi
 DEFAULT_FORMAT_STRING = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
 
@@ -28,8 +28,8 @@ def test_setup_logging_default(
     mock_logger.handlers = []
     mock_logger.reset_mock()  # Reset mock from potential previous tests or module load
 
-    mock_handler_instance = MagicMock(spec=logging.Handler)
-    mock_formatter_instance = MagicMock(spec=logging.Formatter)
+    mock_handler_instance = MagicMock(spec=logging_mod.Handler)
+    mock_formatter_instance = MagicMock(spec=logging_mod.Formatter)
     mock_handler_cls.return_value = mock_handler_instance
     mock_formatter_cls.return_value = mock_formatter_instance
 
@@ -59,11 +59,11 @@ def test_setup_logging_custom_handlers(
     mock_logger.hasHandlers.return_value = False  # No handlers initially
 
     # Use mocks with spec for type compatibility (mypy fix)
-    custom_handler1 = MagicMock(spec=logging.Handler)
-    custom_handler2 = MagicMock(spec=logging.Handler)
-    custom_handlers: list[logging.Handler] = [custom_handler1, custom_handler2]
+    custom_handler1 = MagicMock(spec=logging_mod.Handler)
+    custom_handler2 = MagicMock(spec=logging_mod.Handler)
+    custom_handlers: list[logging_mod.Handler] = [custom_handler1, custom_handler2]
 
-    mock_formatter_instance = MagicMock(spec=logging.Formatter)
+    mock_formatter_instance = MagicMock(spec=logging_mod.Formatter)
     mock_formatter_cls.return_value = mock_formatter_instance
 
     # Call setup_logging with custom handlers
@@ -100,9 +100,9 @@ def test_setup_logging_custom_formatter(
     """Test setup_logging with a custom formatter."""
     mock_logger.handlers = []
     mock_logger.reset_mock()
-    custom_formatter = logging.Formatter("%(levelname)s: %(message)s")
+    custom_formatter = logging_mod.Formatter("%(levelname)s: %(message)s")
 
-    mock_handler_instance = MagicMock(spec=logging.Handler)
+    mock_handler_instance = MagicMock(spec=logging_mod.Handler)
     mock_handler_cls.return_value = mock_handler_instance
 
     # Call setup_logging with custom formatter
@@ -130,10 +130,10 @@ def test_setup_logging_custom_level(
     mock_logger.handlers = []
     mock_logger.reset_mock()
     mock_logger.hasHandlers.return_value = False  # No handlers initially
-    custom_level = logging.DEBUG
+    custom_level = logging_mod.DEBUG
 
-    mock_handler_instance = MagicMock(spec=logging.Handler)
-    mock_formatter_instance = MagicMock(spec=logging.Formatter)
+    mock_handler_instance = MagicMock(spec=logging_mod.Handler)
+    mock_formatter_instance = MagicMock(spec=logging_mod.Formatter)
     mock_handler_cls.return_value = mock_handler_instance
     mock_formatter_cls.return_value = mock_formatter_instance
 
@@ -159,8 +159,8 @@ def test_setup_logging_removes_existing_handlers(
 ) -> None:
     """Test that existing handlers are removed via clear() before adding new ones."""
     # Simulate pre-existing handlers
-    existing_handler1 = MagicMock(spec=logging.Handler)
-    existing_handler2 = MagicMock(spec=logging.Handler)
+    existing_handler1 = MagicMock(spec=logging_mod.Handler)
+    existing_handler2 = MagicMock(spec=logging_mod.Handler)
     # Assign to a separate list first, then assign to mock_logger.handlers
     # This allows us to mock clear() on the list object itself if needed,
     # although checking the final state might be more robust.
@@ -175,8 +175,8 @@ def test_setup_logging_removes_existing_handlers(
     mock_logger.hasHandlers.reset_mock()
     mock_logger.removeHandler.reset_mock()
 
-    mock_new_handler_instance = MagicMock(spec=logging.Handler)
-    mock_formatter_instance = MagicMock(spec=logging.Formatter)
+    mock_new_handler_instance = MagicMock(spec=logging_mod.Handler)
+    mock_formatter_instance = MagicMock(spec=logging_mod.Formatter)
     mock_handler_cls.return_value = mock_new_handler_instance
     mock_formatter_cls.return_value = mock_formatter_instance
 


### PR DESCRIPTION
## Summary
- alias `logging` imports as `logging_mod`
- update all references to avoid variable conflicts

## Testing
- `poetry run pre-commit run --files apiconfig/__init__.py apiconfig/auth/strategies/basic.py apiconfig/auth/strategies/bearer.py apiconfig/auth/token/refresh.py apiconfig/config/base.py apiconfig/config/manager.py apiconfig/types/extensions.py apiconfig/utils/logging/filters.py apiconfig/utils/logging/formatters/detailed.py apiconfig/utils/logging/formatters/redacting.py apiconfig/utils/logging/handlers.py apiconfig/utils/logging/setup.py helpers_for_tests/tripletex/tripletex_auth.py tests/component/test_existing_component_integration.py tests/integration/test_logging_redacting_formatter.py tests/integration/test_tripletex_auth_refresh.py tests/unit/config/test_manager.py tests/unit/utils/logging/formatters/test_detailed.py tests/unit/utils/logging/formatters/test_redacting.py tests/unit/utils/logging/test_filters.py tests/unit/utils/logging/test_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_68699c8844988332bca93d385f259694