### PR TITLE
Update types alias in DetailedFormatter

### DIFF
--- a/apiconfig/utils/logging/formatters/detailed.py
+++ b/apiconfig/utils/logging/formatters/detailed.py
@@ -3,7 +3,7 @@
 
 import logging as logging_mod
 import textwrap
-import types as stdlib_types
+import types as builtin_types
 from typing import Any, Literal, Mapping, Optional
 
 
@@ -82,7 +82,7 @@ class DetailedFormatter(logging_mod.Formatter):
 
     def formatException(
         self,
-        ei: tuple[type[BaseException], BaseException, stdlib_types.TracebackType | None] | tuple[None, None, None],
+        ei: tuple[type[BaseException], BaseException, builtin_types.TracebackType | None] | tuple[None, None, None],
     ) -> str:
         """Format the specified exception information as a string.
 


### PR DESCRIPTION
## Summary
- rename the `types` import alias to `builtin_types`
- update the `TracebackType` references in `DetailedFormatter`

## Testing
- `poetry run pytest -q`
- `poetry run pre-commit run --files apiconfig/utils/logging/formatters/detailed.py`


------
https://chatgpt.com/codex/tasks/task_e_6869b7d4ab388332bd18c9a3aab3fe06