### PR TITLE
fix: simplify bearer auth refresh error

### DIFF
--- a/apiconfig/auth/strategies/bearer.py
+++ b/apiconfig/auth/strategies/bearer.py
@@ -116,8 +116,7 @@ class BearerAuth(AuthStrategy):
         # This is a basic implementation that should be overridden by subclasses
         # or enhanced with specific refresh logic for the use case
         raise NotImplementedError(
-            f"Bearer auth refresh requires custom implementation for {self.__class__.__name__}. "
-            "Override this method or use a specialized auth strategy for your token type."
+            f"Bearer auth refresh requires custom implementation for {self.__class__.__name__}. Override this method or use a specialized auth strategy for your token type."
         )
 
     def prepare_request_headers(self) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- use single f-string for NotImplementedError message

## Testing
- `poetry run pre-commit run --files apiconfig/auth/strategies/bearer.py`

------
https://chatgpt.com/codex/tasks/task_e_6869b7d3a6b48332b9c74a4ad2ba8050