### PR TITLE
Define headers default for TypedLogRecord test

### DIFF
--- a/tests/unit/utils/logging/formatters/test_detailed.py
+++ b/tests/unit/utils/logging/formatters/test_detailed.py
@@ -12,7 +12,7 @@ from apiconfig.utils.logging.formatters import (
 
 
 class TypedLogRecord(logging_mod.LogRecord):
-    headers: dict[str, str]
+    headers: dict[str, str] = {}
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- ensure `TypedLogRecord` initializes a `headers` dictionary

## Testing
- `poetry run pre-commit run --files tests/unit/utils/logging/formatters/test_detailed.py`

------
https://chatgpt.com/codex/tasks/task_e_6869b7d2855c8332bac7ad497fd83e7d