### PR TITLE
Avoid private method usage in tests

### DIFF
--- a/tests/unit/helpers/common/test_base_client.py
+++ b/tests/unit/helpers/common/test_base_client.py
@@ -19,7 +19,14 @@ class DummyAuthStrategy(AuthStrategy):
 
 
 class DummyClient(BaseClient):
-    pass
+    def handle_response(
+        self,
+        response: httpx.Response,
+        method: api_types.HttpMethod,
+        url: str,
+    ) -> api_types.JsonObject | api_types.JsonList:
+        """Expose the protected :py:meth:`_handle_response` for testing."""
+        return self._handle_response(response, method, url)
 
 
 def _make_client() -> DummyClient:
@@ -31,21 +38,21 @@ def test_handle_response_raises_on_error_status() -> None:
     client = _make_client()
     response = httpx.Response(status_code=404, text="not found")
     with pytest.raises(HTTPUtilsError):
-        client._handle_response(
+        client.handle_response(
             response,
             api_types.HttpMethod.GET,
             "https://example.com/test",
-        )  # pyright: ignore[reportPrivateUsage]
+        )
 
 
 def test_handle_response_parses_json() -> None:
     client = _make_client()
     response = httpx.Response(status_code=200, json={"ok": True})
-    result = client._handle_response(
+    result = client.handle_response(
         response,
         api_types.HttpMethod.GET,
         "https://example.com/test",
-    )  # pyright: ignore[reportPrivateUsage]
+    )
     assert result == {"ok": True}
 
 
@@ -53,11 +60,11 @@ def test_handle_response_invalid_json() -> None:
     client = _make_client()
     response = httpx.Response(status_code=200, text="{invalid json")
     with pytest.raises(JSONDecodeError):
-        client._handle_response(
+        client.handle_response(
             response,
             api_types.HttpMethod.GET,
             "https://example.com/test",
-        )  # pyright: ignore[reportPrivateUsage]
+        )
 
 
 @pytest.mark.parametrize("body", ["", "null", "123", '"text"'])
@@ -65,9 +72,9 @@ def test_handle_response_empty_or_non_object_returns_empty_dict(body: str) -> No
     """Non-object JSON bodies should result in an empty dict."""
     client = _make_client()
     response = httpx.Response(status_code=200, text=body)
-    result = client._handle_response(
+    result = client.handle_response(
         response,
         api_types.HttpMethod.GET,
         "https://example.com/test",
-    )  # pyright: ignore[reportPrivateUsage]
+    )
     assert result == {}


### PR DESCRIPTION
## Summary
- expose BaseClient._handle_response via helper method in tests
- use helper in tests and drop pyright ignore comments

## Testing
- `poetry run pre-commit run --files tests/unit/helpers/common/test_base_client.py`

------
https://chatgpt.com/codex/tasks/task_e_6869b7d1d06c8332aef25dbe08b68d77