### PR TITLE
Add explicit Response typing

### DIFF
--- a/apiconfig/testing/integration/helpers.py
+++ b/apiconfig/testing/integration/helpers.py
@@ -80,7 +80,7 @@ def make_request_with_config(
         follow_redirects=True,  # Typically desired in tests
         verify=False,  # Add this for pytest-httpserver compatibility
     ) as client:
-        response = client.request(
+        response: httpx.Response = client.request(
             method=method,
             url=url,
             headers=safe_headers,

--- a/helpers_for_tests/common/base_client.py
+++ b/helpers_for_tests/common/base_client.py
@@ -1,17 +1,9 @@
 """Common base client for API interactions using apiconfig patterns."""
 
 import json
-from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+from typing import Any, Dict, Optional, cast
 
-if TYPE_CHECKING:
-    from httpx import Client, HTTPStatusError, RequestError, Response
-else:
-    import httpx
-
-    Client = httpx.Client
-    HTTPStatusError = httpx.HTTPStatusError
-    RequestError = httpx.RequestError
-    Response = httpx.Response
+from httpx import Client, HTTPStatusError, RequestError, Response
 
 from apiconfig.config.base import ClientConfig
 from apiconfig.exceptions.http import HTTPUtilsError, JSONDecodeError

--- a/tests/unit/helpers/common/test_base_client.py
+++ b/tests/unit/helpers/common/test_base_client.py
@@ -2,6 +2,7 @@ from typing import Dict, Optional
 
 import httpx
 import pytest
+from httpx import Response
 
 import apiconfig.types as api_types
 from apiconfig.auth.base import AuthStrategy
@@ -21,7 +22,7 @@ class DummyAuthStrategy(AuthStrategy):
 class DummyClient(BaseClient):
     def handle_response(
         self,
-        response: httpx.Response,
+        response: Response,
         method: api_types.HttpMethod,
         url: str,
     ) -> api_types.JsonObject | api_types.JsonList:
@@ -36,7 +37,7 @@ def _make_client() -> DummyClient:
 
 def test_handle_response_raises_on_error_status() -> None:
     client = _make_client()
-    response = httpx.Response(status_code=404, text="not found")
+    response: Response = httpx.Response(status_code=404, text="not found")
     with pytest.raises(HTTPUtilsError):
         client.handle_response(
             response,
@@ -47,7 +48,7 @@ def test_handle_response_raises_on_error_status() -> None:
 
 def test_handle_response_parses_json() -> None:
     client = _make_client()
-    response = httpx.Response(status_code=200, json={"ok": True})
+    response: Response = httpx.Response(status_code=200, json={"ok": True})
     result = client.handle_response(
         response,
         api_types.HttpMethod.GET,
@@ -58,7 +59,7 @@ def test_handle_response_parses_json() -> None:
 
 def test_handle_response_invalid_json() -> None:
     client = _make_client()
-    response = httpx.Response(status_code=200, text="{invalid json")
+    response: Response = httpx.Response(status_code=200, text="{invalid json")
     with pytest.raises(JSONDecodeError):
         client.handle_response(
             response,
@@ -71,7 +72,7 @@ def test_handle_response_invalid_json() -> None:
 def test_handle_response_empty_or_non_object_returns_empty_dict(body: str) -> None:
     """Non-object JSON bodies should result in an empty dict."""
     client = _make_client()
-    response = httpx.Response(status_code=200, text=body)
+    response: Response = httpx.Response(status_code=200, text=body)
     result = client.handle_response(
         response,
         api_types.HttpMethod.GET,


### PR DESCRIPTION
## Summary
- import `httpx.Response` in BaseClient test helper
- annotate response variables in tests
- annotate integration helper response variable

## Testing
- `poetry run pre-commit run --files tests/unit/helpers/common/test_base_client.py apiconfig/testing/integration/helpers.py helpers_for_tests/common/base_client.py`

------
https://chatgpt.com/codex/tasks/task_e_6869bff8a4648332b7fc0deb69514d08