### PR TITLE
Add pytest marker types

### DIFF
--- a/typings/pytest/__init__.pyi
+++ b/typings/pytest/__init__.pyi
@@ -5,6 +5,7 @@ from typing import Pattern, Type, overload
 
 from _pytest.fixtures import fixture
 from _pytest.mark import MARK_GEN as mark
+from _pytest.mark.structures import MarkDecorator
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.outcomes import fail, importorskip, skip
 
@@ -30,11 +31,15 @@ def raises(
 ) -> RaisesContext: ...
 
 parametrize = mark.parametrize
+skipif: MarkDecorator = mark.skipif
+asyncio: MarkDecorator = mark.asyncio
 
 __all__ = [
     "fixture",
     "mark",
     "parametrize",
+    "skipif",
+    "asyncio",
     "raises",
     "MonkeyPatch",
     "fail",


### PR DESCRIPTION
## Summary
- update pytest typings to ensure `skipif` and `asyncio` markers are typed

## Testing
- `poetry run pre-commit run --files tests/integration/test_tripletex_auth_refresh.py`

------
https://chatgpt.com/codex/tasks/task_e_6869bff6c5688332a1a6fc7db41686c1